### PR TITLE
Add parser for JSON response 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+vgcore.*

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ CFLAGS=-Wall -pedantic -g
 CFLAGS_LIB=-c
 CURL_LIB=-lcurl
 NCURSES_LIB=-lncurses
-OBJ_FILES=src/ui.c src/api.c src/parser.c
+OBJ_FILES=src/ui.c src/api.c src/parser.c src/pages.c
 BUILD_DIR=build
 BUILD_PATH=$(BUILD_DIR)/ttt.out
 VALGRIND_FLAGS=--leak-check=full --show-leak-kinds=all --suppressions=static/valgrind.supp

--- a/src/api.c
+++ b/src/api.c
@@ -68,8 +68,9 @@ static void create_endpoint_url(char *buf, size_t buf_size, uint16_t start, uint
 static page_collection_t *make_request(uint16_t start, uint16_t end) {
     assert(start != 0);
 
-    if (!curl)
+    if (!curl) {
         api_initialize();
+    }
 
     create_endpoint_url(url_buf, URL_BUF_SIZE, start, end);
     // Create chunk to store data in
@@ -86,8 +87,9 @@ static page_collection_t *make_request(uint16_t start, uint16_t end) {
     res_code = curl_easy_perform(curl);
 
     if (res_code != CURLE_OK) {
-        if (chunk.data)
+        if (chunk.data) {
             free(chunk.data);
+        }
 
         printf("Fetch failed: %s\n", curl_easy_strerror(res_code));
         return NULL;
@@ -121,6 +123,7 @@ page_collection_t *api_get_page(uint16_t page_id) {
 
 page_collection_t *api_get_page_range(uint16_t start, uint16_t end) {
     uint16_t range = end - start;
+
     if (range > MAX_RANGE) {
         // TODO: If the range is larger than the MAX, make several requests or error?
         //       Requesting a large amount of pages will just hang the program for a long time

--- a/src/api.c
+++ b/src/api.c
@@ -68,7 +68,7 @@ static page_collection_t *make_request(uint16_t start, uint16_t end) {
     assert(start != 0);
 
     if (!curl)
-        api_intialize();
+        api_initialize();
 
     create_endpoint_url(url_buf, URL_BUF_SIZE, start, end);
     // Create chunk to store data in
@@ -104,7 +104,7 @@ static page_collection_t *make_request(uint16_t start, uint16_t end) {
     return collection;
 }
 
-void api_intialize() {
+void api_initialize() {
     curl_global_init(CURL_GLOBAL_DEFAULT);
     curl = curl_easy_init();
 

--- a/src/api.c
+++ b/src/api.c
@@ -64,7 +64,7 @@ static void create_endpoint_url(char *buf, size_t buf_size, uint16_t start, uint
 
 
 // TODO: Return error(s) and display in UI
-static page_t *make_request(uint16_t start, uint16_t end) {
+static page_collection_t *make_request(uint16_t start, uint16_t end) {
     assert(start != 0);
 
     if (!curl)
@@ -93,15 +93,15 @@ static page_t *make_request(uint16_t start, uint16_t end) {
     }
 
     printf("Response body: %s\n", chunk.data);
-    page_t *parsed_page = parser_convert_to_page(chunk.data, chunk.size);
+    page_collection_t *collection = parser_convert_to_pages(chunk.data, chunk.size);
     free(chunk.data);
 
-    if (!parsed_page) {
+    if (!collection) {
         printf("Could not parse response body!\n");
         return NULL;
     }
 
-    return parsed_page;
+    return collection;
 }
 
 void api_intialize() {
@@ -114,11 +114,11 @@ void api_intialize() {
     }
 }
 
-page_t *api_get_page(uint16_t page_id) {
+page_collection_t *api_get_page(uint16_t page_id) {
     return make_request(page_id, 0);
 }
 
-page_t *api_get_page_range(uint16_t start, uint16_t end) {
+page_collection_t *api_get_page_range(uint16_t start, uint16_t end) {
     return make_request(start, end);
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -7,6 +7,7 @@
 #define API_ID "terminaltexttv"
 #define URL_BUF_SIZE 256
 #define RANGE_BUF_SIZE 16
+#define MAX_RANGE 5
 
 typedef struct response_chunk {
     char *data;
@@ -119,6 +120,12 @@ page_collection_t *api_get_page(uint16_t page_id) {
 }
 
 page_collection_t *api_get_page_range(uint16_t start, uint16_t end) {
+    uint16_t range = end - start;
+    if (range > MAX_RANGE) {
+        // TODO: If the range is larger than the MAX, make several requests or error?
+        //       Requesting a large amount of pages will just hang the program for a long time
+    }
+
     return make_request(start, end);
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -92,7 +92,7 @@ static page_collection_t *make_request(uint16_t start, uint16_t end) {
         return NULL;
     }
 
-    printf("Response body: %s\n", chunk.data);
+    //printf("Response body: %s\n", chunk.data);
     page_collection_t *collection = parser_convert_to_pages(chunk.data, chunk.size);
     free(chunk.data);
 

--- a/src/api.h
+++ b/src/api.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <curl/curl.h>
 
-enum pages {
+enum page_types {
     HOME = 100,
     NEWS = 101,
     FOREIGN_NEWS = 104,
@@ -15,9 +15,9 @@ enum pages {
     CONTENTS = 700
 };
 
-typedef enum pages pages_t;
+typedef enum page_types page_types_t;
 
 void api_intialize();
-page_t *api_get_page(uint16_t page);
-page_t *api_get_page_range(uint16_t range_start, uint16_t range_end);
+page_collection_t *api_get_page(uint16_t page);
+page_collection_t *api_get_page_range(uint16_t range_start, uint16_t range_end);
 void api_destroy();

--- a/src/api.h
+++ b/src/api.h
@@ -17,7 +17,7 @@ enum page_types {
 
 typedef enum page_types page_types_t;
 
-void api_intialize();
+void api_initialize();
 page_collection_t *api_get_page(uint16_t page);
 page_collection_t *api_get_page_range(uint16_t range_start, uint16_t range_end);
 void api_destroy();

--- a/src/main.c
+++ b/src/main.c
@@ -3,12 +3,21 @@
 #include "parser.h"
 #include <stdlib.h>
 
+// TODO: Move into its own module
+void destroy_page_collection(page_collection_t *collection) {
+    for (size_t i = 0; i < collection->size; i++) {
+        free(collection->pages[i]);
+    }
+
+    free(collection);
+}
+
 int main(void) {
     api_intialize();
-    page_t *home = api_get_page_range(HOME, FOREIGN_NEWS);
-    page_t *news = api_get_page(NEWS);
-    free(home);
-    free(news);
+    /* page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS); */
+    page_collection_t *news = api_get_page(NEWS);
+    /* destroy_page_collection(home); */
+    destroy_page_collection(news);
     api_destroy();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,39 +1,17 @@
 #include "ui.h"
 #include "api.h"
+#include "pages.h"
 #include "parser.h"
 #include <stdlib.h>
 
-// TODO: Move into its own module
-void destroy_page_collection(page_collection_t *collection) {
-    for (size_t i = 0; i < collection->size; i++) {
-        free(collection->pages[i]);
-    }
-
-    free(collection);
-}
-
-void print_parsed_collection(page_collection_t *collection, const char *name) {
-    for (size_t i = 0; i < collection->size; i++) {
-        printf("%s: PAGE %ld\n", name, i);
-        printf("* id: %d\n", collection->pages[i]->id);
-        printf("* prev_id: %d\n", collection->pages[i]->prev_id);
-        printf("* next_id: %d\n", collection->pages[i]->next_id);
-        printf("* unix_date: %zd\n", collection->pages[i]->unix_date);
-        printf("* title: %s\n", collection->pages[i]->title);
-        printf("* content_size: %zd\n", collection->pages[i]->content_size);
-        // TODO: Print parsed content
-        printf("\n");
-    }
-}
-
 int main(void) {
-    api_intialize();
+    api_initialize();
     page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS);
     page_collection_t *news = api_get_page(NEWS);
-    print_parsed_collection(home, "HOME");
-    print_parsed_collection(news, "NEWS");
-    destroy_page_collection(home);
-    destroy_page_collection(news);
+    page_collection_print(home, "HOME");
+    page_collection_print(news, "NEWS");
+    page_collection_destroy(home);
+    page_collection_destroy(news);
     api_destroy();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -12,11 +12,27 @@ void destroy_page_collection(page_collection_t *collection) {
     free(collection);
 }
 
+void print_parsed_collection(page_collection_t *collection, const char *name) {
+    for (size_t i = 0; i < collection->size; i++) {
+        printf("%s: PAGE %ld\n", name, i);
+        printf("* id: %d\n", collection->pages[i]->id);
+        printf("* prev_id: %d\n", collection->pages[i]->prev_id);
+        printf("* next_id: %d\n", collection->pages[i]->next_id);
+        printf("* unix_date: %zd\n", collection->pages[i]->unix_date);
+        printf("* title: %s\n", collection->pages[i]->title);
+        printf("* content_size: %zd\n", collection->pages[i]->content_size);
+        // TODO: Print parsed content
+        printf("\n");
+    }
+}
+
 int main(void) {
     api_intialize();
-    /* page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS); */
+    page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS);
     page_collection_t *news = api_get_page(NEWS);
-    /* destroy_page_collection(home); */
+    print_parsed_collection(home, "HOME");
+    print_parsed_collection(news, "NEWS");
+    destroy_page_collection(home);
     destroy_page_collection(news);
     api_destroy();
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -6,12 +6,9 @@
 
 int main(void) {
     api_initialize();
-    page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS);
-    page_collection_t *news = api_get_page(NEWS);
-    page_collection_print(home, "HOME");
-    page_collection_print(news, "NEWS");
-    page_collection_destroy(home);
-    page_collection_destroy(news);
+    page_collection_t *test = api_get_page_range(HOME, FOREIGN_NEWS);
+    page_collection_print(test, "TEST");
+    page_collection_destroy(test);
     api_destroy();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -3,15 +3,6 @@
 #include "parser.h"
 #include <stdlib.h>
 
-// TODO: Move into its own module
-void destroy_page_collection(page_collection_t *collection) {
-    for (size_t i = 0; i < collection->size; i++) {
-        free(collection->pages[i]);
-    }
-
-    free(collection);
-}
-
 int main(void) {
     api_intialize();
     /* page_collection_t *home = api_get_page_range(HOME, FOREIGN_NEWS); */

--- a/src/pages.c
+++ b/src/pages.c
@@ -14,9 +14,25 @@ void page_collection_print(page_collection_t *collection, const char *name) {
     }
 }
 
+// Internal destroy function for content that is in a page_t struct
+static void post_content_destroy(size_t content_size, post_content_t **content) {
+    for (int i = 0; i < content_size; i++) {
+        post_content_t *current = content[i];
+
+        free(current->title);
+        free(current->text);
+        free(current);
+    }
+    free(content);
+}
+
 void page_destroy(page_t *page) {
+    post_content_destroy(page->content_size, page->content);
+
     free(page->title);
-    // TODO: Free content
+    free(page->content);
+    free(page->content);
+    free(page);
 }
 
 void page_collection_destroy(page_collection_t *collection) {

--- a/src/pages.c
+++ b/src/pages.c
@@ -15,23 +15,21 @@ void page_collection_print(page_collection_t *collection, const char *name) {
 }
 
 // Internal destroy function for content that is in a page_t struct
-static void post_content_destroy(size_t content_size, post_content_t **content) {
-    for (int i = 0; i < content_size; i++) {
+static void post_content_destroy(post_content_t **content, size_t content_size) {
+    for (size_t i = 0; i < content_size; i++) {
         post_content_t *current = content[i];
 
         free(current->title);
         free(current->text);
         free(current);
     }
+
     free(content);
 }
 
 void page_destroy(page_t *page) {
-    post_content_destroy(page->content_size, page->content);
-
+    post_content_destroy(page->content, page->content_size);
     free(page->title);
-    free(page->content);
-    free(page->content);
     free(page);
 }
 
@@ -40,5 +38,6 @@ void page_collection_destroy(page_collection_t *collection) {
         page_destroy(collection->pages[i]);
     }
 
+    free(collection->pages);
     free(collection);
 }

--- a/src/pages.c
+++ b/src/pages.c
@@ -1,0 +1,28 @@
+#include "pages.h"
+
+void page_collection_print(page_collection_t *collection, const char *name) {
+    for (size_t i = 0; i < collection->size; i++) {
+        printf("%s: PAGE %ld\n", name, i);
+        printf("* id: %d\n", collection->pages[i]->id);
+        printf("* prev_id: %d\n", collection->pages[i]->prev_id);
+        printf("* next_id: %d\n", collection->pages[i]->next_id);
+        printf("* unix_date: %zd\n", collection->pages[i]->unix_date);
+        printf("* title: %s\n", collection->pages[i]->title);
+        printf("* content_size: %zd\n", collection->pages[i]->content_size);
+        // TODO: Print parsed content
+        printf("\n");
+    }
+}
+
+void page_destroy(page_t *page) {
+    free(page->title);
+    // TODO: Free content
+}
+
+void page_collection_destroy(page_collection_t *collection) {
+    for (size_t i = 0; i < collection->size; i++) {
+        page_destroy(collection->pages[i]);
+    }
+
+    free(collection);
+}

--- a/src/pages.c
+++ b/src/pages.c
@@ -16,14 +16,16 @@ void page_collection_print(page_collection_t *collection, const char *name) {
 
 // Internal destroy function for content that is in a page_t struct
 static void post_content_destroy(post_content_t **content, size_t content_size) {
-    if (!content)
+    if (!content) {
         return;
+    }
 
     for (size_t i = 0; i < content_size; i++) {
         post_content_t *current = content[i];
 
-        if (!current)
+        if (!current) {
             continue;
+        }
 
         free(current->title);
         free(current->text);

--- a/src/pages.c
+++ b/src/pages.c
@@ -16,8 +16,14 @@ void page_collection_print(page_collection_t *collection, const char *name) {
 
 // Internal destroy function for content that is in a page_t struct
 static void post_content_destroy(post_content_t **content, size_t content_size) {
+    if (!content)
+        return;
+
     for (size_t i = 0; i < content_size; i++) {
         post_content_t *current = content[i];
+
+        if (!current)
+            continue;
 
         free(current->title);
         free(current->text);

--- a/src/pages.h
+++ b/src/pages.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+typedef struct page page_t;
+typedef struct post post_t;
+typedef struct page_collection page_collection_t;
+typedef struct post_content post_content_t;
+typedef enum post_content_type {
+    HEADLINE,
+    ARTICLE
+} post_content_type_t;
+
+struct post_content {
+    char *title;
+    char *text;
+    uint16_t id;
+    post_content_type_t type;
+};
+
+struct page {
+    uint16_t id, prev_id, next_id;
+    uint64_t unix_date;
+    char *title;
+    size_t content_size;
+    post_content_t **content;
+};
+
+struct page_collection {
+    page_t **pages;
+    size_t size;
+};
+
+void page_destroy(page_t *page);
+void page_collection_print(page_collection_t *collection, const char *name);
+void page_collection_destroy(page_collection_t *collection);

--- a/src/parser.c
+++ b/src/parser.c
@@ -31,7 +31,7 @@ static post_content_t **get_content(const char *data, jsmntok_t token) {
     return content;
 }
 
-static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsmntok_t next_token) {
+static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsmntok_t next_token, size_t *index) {
     char *value = NULL;
     char *key = get_string_value(data, token);
 
@@ -86,9 +86,12 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "title") == 0) {
         page->title = get_string_value(data, next_token);
     } else if (strcmp(key, "content") == 0) {
+        *index += next_token.size;
         page->content_size = next_token.size;
         page->content = get_content(data, next_token);
     }
+
+    *index += 1;
 
     free(key);
 }
@@ -102,18 +105,7 @@ static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, 
 
     while (iterations < obj.size) {
         cursor = tokens[i];
-
-        parse_key_value(page, data, cursor, tokens[i + 1]);
-
-        if (cursor.type == JSMN_STRING || cursor.type == JSMN_PRIMITIVE) {
-            i++;
-        } else if (cursor.type == JSMN_ARRAY) {
-            i += cursor.size;
-        } else {
-            printf("Found unhandled token type in page: %d\n", cursor.type);
-            continue;
-        }
-
+        parse_key_value(page, data, cursor, tokens[i + 1], &i);
         iterations++;
         i++;
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,36 +1,53 @@
 #include "parser.h"
+#include <string.h>
 #include "../lib/jsmn.h"
 
-#define NO_TOKENS 128
+#define TOKENS_SIZE 128
+#define EXPECTED_OBJECT_SIZE 8
 
-struct post_content {
-    char *title;
-    char *text;
-    uint16_t id;
-    post_content_type_t type;
-    post_content_t *next;
-};
+static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, size_t obj_index) {
+    jsmntok_t cursor;
+    page_t *page = calloc(1, sizeof(page_t));
 
-struct page {
-    uint16_t id, prev_id, next_id;
-    uint64_t unix_date;
-    char *title;
-    post_content_t *content;
-};
+    for (size_t i = 1; i <= obj.size; i++) {
+        cursor = tokens[i + obj_index];
 
-page_t *parser_convert_to_page(const char *data, size_t size) {
+        if (cursor.type == JSMN_STRING) {
+            printf("PAGE - String: %d\n", cursor.size);
+        } else if (cursor.type == JSMN_ARRAY) {
+            printf("PAGE - Array size: %d\n", cursor.size);
+        } else if (cursor.type == JSMN_PRIMITIVE) {
+            printf("PAGE - Primitive: %d\n", cursor.size);
+        } else {
+            printf("Found unhandled token type in page: %d\n", cursor.type);
+            continue;
+        }
+    }
+
+    *page = (page_t) {
+        .id = 0,
+        .prev_id = 0,
+        .next_id = 0,
+        .unix_date = 0,
+        .title = "Hello from parser",
+        .content = NULL,
+    };
+
+    return page;
+}
+
+page_collection_t *parser_convert_to_pages(const char *data, size_t size) {
     if (!data || size == 0) {
         return NULL;
     }
 
     jsmn_parser parser;
     jsmn_init(&parser);
-    jsmntok_t tokens[NO_TOKENS];
-    int keys = jsmn_parse(&parser, data, size, tokens, sizeof(tokens) / sizeof(tokens[0]));
-    printf("keys: %d\n", keys);
+    jsmntok_t tokens[TOKENS_SIZE];
+    size_t keys = jsmn_parse(&parser, data, size, tokens, sizeof(tokens) / sizeof(tokens[0]));
 
     if (keys < 0) {
-        printf("Failed to parse response body!\n");
+        printf("Failed to parse response body: %ld\n", keys);
         return NULL;
     }
 
@@ -39,23 +56,39 @@ page_t *parser_convert_to_page(const char *data, size_t size) {
         return NULL;
     }
 
-    int pages = 0;
+    jsmntok_t array = tokens[0];
+    printf("JSON array size: %d\n", array.size);
 
-    for (int i = 1; i < keys; i++) {
-        if (tokens[i].type == JSMN_OBJECT) {
-            printf("Contains page!\n");
-            pages++;
+    size_t parsed_objects = 0;
+    page_t **pages = calloc(array.size, sizeof(page_t*));
+
+    for (size_t i = 1; i < keys; i++) {
+        jsmntok_t token = tokens[i];
+
+        printf("Index: %zd\n", i);
+        if (token.type == JSMN_OBJECT) {
+            if (token.size != EXPECTED_OBJECT_SIZE) {
+                printf("Failed to parse JSON page object with invalid size: %d\n", token.size);
+                continue;
+            }
+
+            page_t *page = parse_object(data, token, tokens, i);
+
+            // Move forward to the first token after the current page object
+            i += token.size;
+
+            if (page) {
+                pages[parsed_objects] = page;
+                parsed_objects++;
+            }
+        } else {
+            printf("Key type: %d\n", token.type);
         }
     }
 
-    page_t *page = calloc(1, sizeof(page_t));
-    *page = (page_t) {
-        .id = 0,
-        .prev_id = 0,
-        .next_id = 0,
-        .unix_date = 0,
-        .title = "Hello from parser",
-        .content = NULL
-    };
-    return page;
+    page_collection_t *collection = calloc(1, sizeof(page_collection_t));
+    collection->pages = pages;
+    collection->size = parsed_objects;
+
+    return collection;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,11 +5,11 @@
 
 static char *get_string_value(const char *data, jsmntok_t token) {
     assert(data != NULL);
-
     size_t length = token.end - token.start;
 
-    if (length == 0)
+    if (length == 0) {
         return NULL;
+    }
 
     char *str = calloc(length + 1, sizeof(char));
     str[length] = '\0';
@@ -20,8 +20,7 @@ static char *get_string_value(const char *data, jsmntok_t token) {
 // TODO: Pass in the entire tokens array so that we can loop through all items
 static post_content_t **get_content(const char *data, jsmntok_t token) {
     /* char *content_string; */
-
-    post_content_t **content = calloc(token.size, sizeof(post_content_t*));
+    post_content_t **content = calloc(token.size, sizeof(post_content_t *));
 
     for (size_t i = 0; i < token.size; i++) {
         /* content_string = get_string_value(data, token) */
@@ -37,7 +36,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     if (strcmp(key, "num") == 0) {
         value = get_string_value(data, next_token);
         uint16_t id = atoi(value);
-
         free(value);
 
         if (!id) {
@@ -49,7 +47,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "prev_page") == 0) {
         value = get_string_value(data, next_token);
         uint16_t prev_id = atoi(value);
-
         free(value);
 
         if (!prev_id) {
@@ -61,7 +58,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "next_page") == 0) {
         value = get_string_value(data, next_token);
         uint16_t next_id = atoi(value);
-
         free(value);
 
         if (!next_id) {
@@ -73,7 +69,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "date_updated_unix") == 0) {
         value = get_string_value(data, next_token);
         uint64_t date = atoi(value);
-
         free(value);
 
         if (!date) {
@@ -91,7 +86,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     }
 
     *index += 1;
-
     free(key);
 }
 
@@ -133,7 +127,7 @@ page_collection_t *parser_convert_to_pages(const char *data, size_t size) {
 
     size_t parsed_objects = 0;
     jsmntok_t array = tokens[0];
-    page_t **pages = calloc(array.size, sizeof(page_t*));
+    page_t **pages = calloc(array.size, sizeof(page_t *));
 
     for (size_t i = 1; i < keys; i++) {
         jsmntok_t token = tokens[i];
@@ -151,6 +145,5 @@ page_collection_t *parser_convert_to_pages(const char *data, size_t size) {
     page_collection_t *collection = calloc(1, sizeof(page_collection_t));
     collection->pages = pages;
     collection->size = parsed_objects;
-
     return collection;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -75,6 +75,8 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "title") == 0) {
         page->title = get_string_value(data, next_token);
     }
+
+    free(key);
 }
 
 // TODO: Fix memory leaks

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,6 +1,4 @@
 #include "parser.h"
-#include <assert.h>
-#include <string.h>
 #include "../lib/jsmn.h"
 
 #define TOKENS_SIZE 128
@@ -25,9 +23,12 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     char *key = get_string_value(data, token);
 
     // TODO: Why the fuk does only num work?
+    // TODO: Abstraction
     if (strcmp(key, "num") == 0) {
         value = get_string_value(data, next_token);
         uint16_t id = atoi(value);
+
+        free(value);
 
         if (!id) {
             printf("Expected numeric value for key, but got string: %s\n", value);
@@ -39,6 +40,8 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
         value = get_string_value(data, next_token);
         uint16_t prev_id = atoi(value);
 
+        free(value);
+
         if (!prev_id) {
             printf("Expected numeric value for key, but got string: %s\n", value);
             return;
@@ -49,6 +52,8 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
         value = get_string_value(data, next_token);
         uint16_t next_id = atoi(value);
 
+        free(value);
+
         if (!next_id) {
             printf("Expected numeric value for key, but got string: %s\n", value);
             return;
@@ -58,6 +63,8 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     } else if (strcmp(key, "date_updated_unix") == 0) {
         value = get_string_value(data, next_token);
         uint64_t date = atoi(value);
+
+        free(value);
 
         if (!date) {
             printf("Expected numeric value for key, but got string: %s\n", value);
@@ -70,6 +77,7 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     }
 }
 
+// TODO: Fix memory leaks
 static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, size_t *obj_index) {
     jsmntok_t cursor;
     page_t *page = calloc(1, sizeof(page_t));

--- a/src/parser.c
+++ b/src/parser.c
@@ -1,8 +1,7 @@
 #include "parser.h"
 #include "../lib/jsmn.h"
 
-#define TOKENS_SIZE 128
-#define EXPECTED_OBJECT_SIZE 8
+#define TOKENS_SIZE 256
 
 static char *get_string_value(const char *data, jsmntok_t token) {
     assert(data != NULL);
@@ -140,11 +139,6 @@ page_collection_t *parser_convert_to_pages(const char *data, size_t size) {
         jsmntok_t token = tokens[i];
 
         if (token.type == JSMN_OBJECT) {
-            if (token.size != EXPECTED_OBJECT_SIZE) {
-                printf("Failed to parse JSON page object with invalid size: %d\n", token.size);
-                continue;
-            }
-
             page_t *page = parse_object(data, token, tokens, &i);
 
             if (page) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -92,3 +92,11 @@ page_collection_t *parser_convert_to_pages(const char *data, size_t size) {
 
     return collection;
 }
+
+void destroy_page_collection(page_collection_t *collection) {
+    for (size_t i = 0; i < collection->size; i++) {
+        free(collection->pages[i]);
+    }
+
+    free(collection);
+}

--- a/src/parser.c
+++ b/src/parser.c
@@ -18,12 +18,23 @@ static char *get_string_value(const char *data, jsmntok_t token) {
     return str;
 }
 
+// TODO: Pass in the entire tokens array so that we can loop through all items
+static post_content_t **get_content(const char *data, jsmntok_t token) {
+    /* char *content_string; */
+
+    post_content_t **content = calloc(token.size, sizeof(post_content_t*));
+
+    for (size_t i = 0; i < token.size; i++) {
+        /* content_string = get_string_value(data, token) */
+    }
+
+    return content;
+}
+
 static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsmntok_t next_token) {
     char *value = NULL;
     char *key = get_string_value(data, token);
 
-    // TODO: Why the fuk does only num work?
-    // TODO: Abstraction
     if (strcmp(key, "num") == 0) {
         value = get_string_value(data, next_token);
         uint16_t id = atoi(value);
@@ -74,6 +85,9 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
         page->unix_date = date;
     } else if (strcmp(key, "title") == 0) {
         page->title = get_string_value(data, next_token);
+    } else if (strcmp(key, "content") == 0) {
+        page->content_size = next_token.size;
+        page->content = get_content(data, next_token);
     }
 
     free(key);
@@ -89,11 +103,11 @@ static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, 
     while (iterations < obj.size) {
         cursor = tokens[i];
 
+        parse_key_value(page, data, cursor, tokens[i + 1]);
+
         if (cursor.type == JSMN_STRING || cursor.type == JSMN_PRIMITIVE) {
-            parse_key_value(page, data, cursor, tokens[i + 1]);
             i++;
         } else if (cursor.type == JSMN_ARRAY) {
-            // TODO: Parse array
             i += cursor.size;
         } else {
             printf("Found unhandled token type in page: %d\n", cursor.type);

--- a/src/parser.c
+++ b/src/parser.c
@@ -96,7 +96,6 @@ static void parse_key_value(page_t *page, const char *data, jsmntok_t token, jsm
     free(key);
 }
 
-// TODO: Fix memory leaks
 static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, size_t *obj_index) {
     jsmntok_t cursor;
     page_t *page = calloc(1, sizeof(page_t));
@@ -109,9 +108,6 @@ static page_t *parse_object(const char *data, jsmntok_t obj, jsmntok_t *tokens, 
         iterations++;
         i++;
     }
-
-    // TODO: Should we have -1?
-    *obj_index = i - 1;
 
     return page;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -4,11 +4,33 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-enum post_content_type { HEADLINE, ARTICLE };
-
 typedef struct page page_t;
 typedef struct post post_t;
+typedef struct page_collection page_collection_t;
 typedef struct post_content post_content_t;
-typedef enum post_content_type post_content_type_t;
+typedef enum post_content_type {
+    HEADLINE,
+    ARTICLE
+} post_content_type_t;
 
-page_t *parser_convert_to_page(const char *data, size_t size);
+struct post_content {
+    char *title;
+    char *text;
+    uint16_t id;
+    post_content_type_t type;
+};
+
+struct page {
+    uint16_t id, prev_id, next_id;
+    uint64_t unix_date;
+    char *title;
+    size_t content_size;
+    post_content_t **content;
+};
+
+struct page_collection {
+    page_t **pages;
+    size_t size;
+};
+
+page_collection_t *parser_convert_to_pages(const char *data, size_t size);

--- a/src/parser.h
+++ b/src/parser.h
@@ -34,3 +34,4 @@ struct page_collection {
 };
 
 page_collection_t *parser_convert_to_pages(const char *data, size_t size);
+void destroy_page_collection(page_collection_t *collection);

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,36 +1,10 @@
 #pragma once
+#include "pages.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
-
-typedef struct page page_t;
-typedef struct post post_t;
-typedef struct page_collection page_collection_t;
-typedef struct post_content post_content_t;
-typedef enum post_content_type {
-    HEADLINE,
-    ARTICLE
-} post_content_type_t;
-
-struct post_content {
-    char *title;
-    char *text;
-    uint16_t id;
-    post_content_type_t type;
-};
-
-struct page {
-    uint16_t id, prev_id, next_id;
-    uint64_t unix_date;
-    char *title;
-    size_t content_size;
-    post_content_t **content;
-};
-
-struct page_collection {
-    page_t **pages;
-    size_t size;
-};
+#include <assert.h>
+#include <string.h>
 
 page_collection_t *parser_convert_to_pages(const char *data, size_t size);


### PR DESCRIPTION
The entire JSON response in #7 is parsed into a `page_t`'. The content string is not yet parsed, but there is an open issue for this at #12. It requires a different parsing method since it is HTML. 

If the response from the API contains multiple pages, e.g. with `api_get_page_range()`, they are parsed independently into different pages and stored in the `page_collection_t` struct. 

