### PR TITLE
feat: add base UI and help page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ Mkfile.old
 dkms.conf
 
 vgcore.*
+bin/

--- a/docs/parser/html.md
+++ b/docs/parser/html.md
@@ -1,20 +1,25 @@
 # HTML content parsing
 ## Tokens
-The HTML content is parsed into rows, where each row has a fixed size of 42
-characters (as defined by `PAGE_COLS` in `src/shared.h`). Each row is an array of
-`tokens` which will have all the attributes needed for the UI to render them
-properly. To fully render a row, iterate through the token array until the token
-type is `PAGE_TOKEN_END`.
+The HTML content is parsed into an array of tokens and since the data that is
+received from the API always has 42 characters between `\n`, line-wrapping in
+ncurses will automatically handle new rows. Each token which will have all the
+attributes needed for the UI to render it properly.
+
+Rendering of the tokens is done by iterating through each token until
+`PAGE_TOKEN_END` is found. `PAGE_TOKEN_NEWLINE` marks the end of the current
+line. However, new lines does not have to be handled manually, since the total
+character length of all previous tokens (after the previous `PAGE_TOKEN_NEWLINE`
+or start of the array) will always be 42 characters (as defined by `PAGE_COLS`).
 
 ### Types
-There are 4 different token types:
+There are 5 different token types:
 ```c
 typedef enum page_token_type {
-    PAGE_TOKEN_HEADER,      // is used when token has the `.toprow` class
-    PAGE_TOKEN_TEXT,        // is used when token is not empty without attributes
-    PAGE_TOKEN_WHITESPACE,  // is used when the token is empty
-    PAGE_TOKEN_LINK,        // is used when the token is surrounded by the `<a>` tag
-    PAGE_TOKEN_END,         // is used when the `\n` is found in the text
+    PAGE_TOKEN_TEXT,
+    PAGE_TOKEN_WHITESPACE,
+    PAGE_TOKEN_LINK,
+    PAGE_TOKEN_NEWLINE,
+    PAGE_TOKEN_END
 } page_token_type_t;
 ```
 
@@ -24,8 +29,8 @@ Each token will have a style, as defined by the struct:
 typedef struct page_token_style page_token_style_t;
 
 struct page_token_style {
-    page_token_attr_t fg;    // foreground color
-    page_token_attr_t bg;    // background color
+    page_token_attr_t fg;
+    page_token_attr_t bg;
     page_token_attr_t extra; // other attributes, e.g. bold text
 };
 ```

--- a/docs/parser/html.md
+++ b/docs/parser/html.md
@@ -1,0 +1,196 @@
+# HTML content parsing
+## Tokens
+The HTML content is parsed into rows, where each row has a fixed size of 42
+characters (as defined by `PAGE_COLS` in `src/shared.h`). Each row is an array of
+`tokens` which will have all the attributes needed for the UI to render them
+properly. To fully render a row, iterate through the token array until the token
+type is `PAGE_TOKEN_END`.
+
+### Types
+There are 4 different token types:
+```c
+typedef enum page_token_type {
+    PAGE_TOKEN_HEADER,      // is used when token has the `.toprow` class
+    PAGE_TOKEN_TEXT,        // is used when token is not empty without attributes
+    PAGE_TOKEN_WHITESPACE,  // is used when the token is empty
+    PAGE_TOKEN_LINK,        // is used when the token is surrounded by the `<a>` tag
+    PAGE_TOKEN_END,         // is used when the `\n` is found in the text
+} page_token_type_t;
+```
+
+### Styling
+Each token will have a style, as defined by the struct:
+```c
+typedef struct page_token_style page_token_style_t;
+
+struct page_token_style {
+    page_token_attr_t fg;    // foreground color
+    page_token_attr_t bg;    // background color
+    page_token_attr_t extra; // other attributes, e.g. bold text
+};
+```
+
+The available attributes for the style are the following:
+```c
+typedef enum page_token_attr {
+    PAGE_TOKEN_ATTR_BOLD,       // .DH
+    PAGE_TOKEN_ATTR_BLUE,       // .B
+    PAGE_TOKEN_ATTR_CYAN,       // .C
+    PAGE_TOKEN_ATTR_WHITE,      // .W
+    PAGE_TOKEN_ATTR_GREEN,      // .G
+    PAGE_TOKEN_ATTR_YELLOW,     // .Y
+    PAGE_TOKEN_ATTR_RED,        // .R
+    PAGE_TOKEN_ATTR_BG_BLUE,    // .bgB
+    PAGE_TOKEN_ATTR_BG_CYAN,    // .bgC
+    PAGE_TOKEN_ATTR_BG_WHITE,   // .bgW
+    PAGE_TOKEN_ATTR_BG_GREEN,   // .bgG
+    PAGE_TOKEN_ATTR_BG_YELLOW,  // .bgY
+    PAGE_TOKEN_ATTR_BG_RED,     // .bgR
+} page_token_attr_t;
+```
+
+### Colors
+This CSS-code shows all the possible classes and the styling that is used
+(extracted from [texttv.nu](https://texttv.nu/)):
+
+```css
+.TextTVPage
+a {
+	color: rgb(221, 221, 221)
+}
+
+.TextTVPage
+.root {
+	white-space: pre
+}
+
+.TextTVPage .root
+.toprow {
+	color: #ddd;
+	line-height: 1
+}
+
+.TextTVPage .inpage-pages {
+	list-style-type: none;
+	margin: 0;
+	padding: 0
+}
+
+.TextTVPage h1,
+.TextTVPage
+h2 {
+	font-size: 100%;
+	display: inline
+}
+
+.TextTVPage
+.B {
+	color: #336
+}
+
+.TextTVPage
+.C {
+	color: #066
+}
+
+.TextTVPage
+.W {
+	color: #333
+}
+
+.TextTVPage
+.Y {
+	color: #660
+}
+
+.TextTVPage
+.DH {
+	font-weight: normal;
+	font-family: 'Ubuntu Mono',Courier;
+	font-weight: 700
+}
+
+.TextTVPage .bgB,
+.TextTVPage .bgB a
+span {
+}
+
+.TextTVPage .bgW,
+.TextTVPage .bgW a
+span {
+	background-color: orange
+}
+
+.TextTVPage .bgG,
+.TextTVPage .bgG a
+span {
+	background-color: rgba(0,255,0,.5)
+}
+
+.TextTVPage .bgR,
+.TextTVPage .bgR a
+span {
+	background-color: rgba(255,0,0,.25)
+}
+
+.TextTVPage .bgC,
+.TextTVPage .bgC a
+span {
+	background-color: rgb(0, 200, 238)
+}
+
+.TextTVPage .R,
+.TextTVPage .R a,
+.TextTVPage .R a:visited,
+.TextTVPage .R a:visited:hover {
+	color: #F00
+}
+
+.TextTVPage .B,
+.TextTVPage .B
+a {
+	color: #12C
+}
+
+.TextTVPage .W,
+.TextTVPage .W
+a {
+	color: #ddd
+}
+
+.TextTVPage .Y,
+.TextTVPage .Y
+a {
+	color: #e2e200
+}
+
+.TextTVPage .C,
+.TextTVPage .C
+a {
+	color: #00c8ee
+}
+
+.TextTVPage .bgB,
+.TextTVPage .bgB
+a {
+	background-color: #00f;
+	color: #ddd
+}
+
+.TextTVPage
+.DH {
+}
+
+.TextTVPage .G,
+.TextTVPage .G
+a {
+	color: #0F0
+}
+
+.TextTVPage .bgY,
+.TextTVPage .bgY
+a {
+	background-color: #e2e200;
+	color: #12C
+}
+```

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ LIBS=-lcurl -lncurses
 TEST_LIBS=-lcunit
 
 BASE_OBJ_FILES:=src/parser.o src/pages.o src/errors.c
-OBJ_FILES:=src/ui.o src/api.o $(BASE_OBJ_FILES)
+OBJ_FILES:=src/ui.o src/api.o src/draw.c src/colors.c $(BASE_OBJ_FILES)
 MAIN_FILES:=src/main.c $(OBJ_FILES)
 TEST_FILES:=test/unittests.c $(BASE_OBJ_FILES)
 

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ CFLAGS_LIB=-c
 LIBS=-lcurl -lncurses
 TEST_LIBS=-lcunit
 
-BASE_OBJ_FILES:=src/parser.o src/pages.o
+BASE_OBJ_FILES:=src/parser.o src/pages.o src/errors.c
 OBJ_FILES:=src/ui.o src/api.o $(BASE_OBJ_FILES)
 MAIN_FILES:=src/main.c $(OBJ_FILES)
 TEST_FILES:=test/unittests.c $(BASE_OBJ_FILES)

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ CC=gcc
 CFLAGS=-Wall -pedantic -g
 CFLAGS_LIB=-c
 
-LIBS=-lcurl -lncurses
+LIBS=-lcurl -lncursesw
 TEST_LIBS=-lcunit
 
 BASE_OBJ_FILES:=src/parser.o src/pages.o src/errors.c

--- a/makefile
+++ b/makefile
@@ -10,9 +10,9 @@ OBJ_FILES:=src/ui.o src/api.o $(BASE_OBJ_FILES)
 MAIN_FILES:=src/main.c $(OBJ_FILES)
 TEST_FILES:=test/unittests.c $(BASE_OBJ_FILES)
 
-DIST_DIR=build
-TTT_OUT_PATH=$(DIST_DIR)/ttt.out
-TEST_OUT_PATH=$(DIST_DIR)/tests.out
+DIST_DIR=bin
+TTT_OUT_PATH=$(DIST_DIR)/ttt
+TEST_OUT_PATH=$(DIST_DIR)/ttt_tests
 
 VALGRIND_FLAGS=--leak-check=full \
 	       --show-leak-kinds=all \
@@ -32,8 +32,14 @@ unittests: prebuild $(TEST_FILES)
 run: main
 	./$(TTT_OUT_PATH)
 
+runr: main
+	./$(TTT_OUT_PATH) -r
+
 memrun: main
 	valgrind $(VALGRIND_FLAGS) ./$(TTT_OUT_PATH)
+
+memrunr: main
+	valgrind $(VALGRIND_FLAGS) ./$(TTT_OUT_PATH) -r
 
 test: unittests
 	./$(TEST_OUT_PATH)

--- a/src/api.c
+++ b/src/api.c
@@ -1,8 +1,4 @@
 #include "api.h"
-#include <stdlib.h>
-#include <string.h>
-#include <assert.h>
-#include <curl/curl.h>
 
 #define API_ID "terminaltexttv"
 #define URL_BUF_SIZE 256
@@ -24,7 +20,10 @@ static size_t write_callback(void *data, size_t size, size_t nmemb, void *extra)
     char *ptr = realloc(mem->data, mem->size + realsize + 1);
 
     if (ptr == NULL) {
-        printf("Out of memory!\n");
+        error_set_with_string(
+            TTT_ERROR_OUT_OF_MEMORY,
+            "ERROR: Failed to allocate memory for response text chunk"
+        );
         return 0;
     }
 
@@ -90,19 +89,13 @@ static page_collection_t *make_request(uint16_t start, uint16_t end) {
             free(chunk.data);
         }
 
-        printf("Fetch failed: %s\n", curl_easy_strerror(res_code));
+        error_set_with_string(TTT_ERROR_REQUEST_FAILED, curl_easy_strerror(res_code));
         return NULL;
     }
 
     /* printf("Response body: %s\n", chunk.data); */
     page_collection_t *collection = parser_get_page_collection(chunk.data, chunk.size);
     free(chunk.data);
-
-    if (!collection) {
-        printf("Could not parse response body!\n");
-        return NULL;
-    }
-
     return collection;
 }
 

--- a/src/api.c
+++ b/src/api.c
@@ -3,7 +3,6 @@
 #define API_ID "terminaltexttv"
 #define URL_BUF_SIZE 256
 #define RANGE_BUF_SIZE 16
-#define MAX_RANGE 5
 
 typedef struct response_chunk {
     char *data;
@@ -116,7 +115,7 @@ page_collection_t *api_get_page(uint16_t page_id) {
 page_collection_t *api_get_page_range(uint16_t start, uint16_t end) {
     uint16_t range = end - start;
 
-    if (range > MAX_RANGE) {
+    if (range > MAX_PAGE_COLLECTION_SIZE) {
         // TODO: If the range is larger than the MAX, make several requests or error?
         //       Requesting a large amount of pages will just hang the program for a long time
     }

--- a/src/api.h
+++ b/src/api.h
@@ -1,21 +1,25 @@
 #pragma once
-#include "parser.h"
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
 #include <curl/curl.h>
 
-enum page_types {
-    HOME = 100,
-    NEWS = 101,
-    FOREIGN_NEWS = 104,
-    ECONOMY = 200,
-    SPORT = 300,
-    STOCK_MARKET = 330,
-    SPORT_SERVICE = 376,
-    TV = 600,
-    CONTENTS = 700
-};
+#include "shared.h"
+#include "parser.h"
+#include "errors.h"
 
-typedef enum page_types page_types_t;
+typedef enum api_pages {
+    TTT_PAGE_HOME = 100,
+    TTT_PAGE_NEWS = 101,
+    TTT_PAGE_FOREIGN_NEWS = 104,
+    TTT_PAGE_ECONOMY = 200,
+    TTT_PAGE_SPORT = 300,
+    TTT_PAGE_STOCK_MARKET = 330,
+    TTT_PAGE_SPORT_SERVICE = 376,
+    TTT_PAGE_TV = 600,
+    TTT_PAGE_CONTENTS = 700
+} api_pages_t;
 
 void api_initialize();
 page_collection_t *api_get_page(uint16_t page);

--- a/src/colors.c
+++ b/src/colors.c
@@ -10,4 +10,5 @@ void colors_initialize() {
     init_pair(COLORSCHEME_DEFAULT,  COLOR_WHITE,    COLOR_BLACK);
     init_pair(COLORSCHEME_YB,       COLOR_YELLOW,   COLOR_BLUE);
     init_pair(COLORSCHEME_BY,       COLOR_BLUE,     COLOR_YELLOW);
+    init_pair(COLORSCHEME_YX,       COLOR_YELLOW,   COLOR_BLACK);
 }

--- a/src/colors.c
+++ b/src/colors.c
@@ -4,9 +4,10 @@ void colors_initialize() {
     start_color();
     use_default_colors();
     init_color(COLOR_BLACK, 0, 0, 0);
-    init_color(COLOR_BLUE, 0, 0, 500);
+    init_color(COLOR_BLUE, 0, 0, 850);
     init_color(COLOR_YELLOW, 1000, 1000, 0);
     init_color(COLOR_WHITE, 1000, 1000, 1000);
-    init_pair(COLORSCHEME_DEFAULT, COLOR_WHITE,   COLOR_BLACK);
-    init_pair(COLORSCHEME_HEADER,  COLOR_YELLOW,  COLOR_BLUE);
+    init_pair(COLORSCHEME_DEFAULT,  COLOR_WHITE,    COLOR_BLACK);
+    init_pair(COLORSCHEME_YB,       COLOR_YELLOW,   COLOR_BLUE);
+    init_pair(COLORSCHEME_BY,       COLOR_BLUE,     COLOR_YELLOW);
 }

--- a/src/colors.c
+++ b/src/colors.c
@@ -1,0 +1,12 @@
+#include "colors.h"
+
+void colors_initialize() {
+    start_color();
+    use_default_colors();
+    init_color(COLOR_BLACK, 0, 0, 0);
+    init_color(COLOR_BLUE, 0, 0, 500);
+    init_color(COLOR_YELLOW, 1000, 1000, 0);
+    init_color(COLOR_WHITE, 1000, 1000, 1000);
+    init_pair(COLORSCHEME_DEFAULT, COLOR_WHITE,   COLOR_BLACK);
+    init_pair(COLORSCHEME_HEADER,  COLOR_YELLOW,  COLOR_BLUE);
+}

--- a/src/colors.c
+++ b/src/colors.c
@@ -8,6 +8,7 @@ void colors_initialize() {
     init_color(COLOR_YELLOW, 1000, 1000, 0);
     init_color(COLOR_WHITE, 1000, 1000, 1000);
     init_pair(COLORSCHEME_DEFAULT,  COLOR_WHITE,    COLOR_BLACK);
+    init_pair(COLORSCHEME_BW,       COLOR_BLACK,    COLOR_WHITE);
     init_pair(COLORSCHEME_YB,       COLOR_YELLOW,   COLOR_BLUE);
     init_pair(COLORSCHEME_BY,       COLOR_BLUE,     COLOR_YELLOW);
     init_pair(COLORSCHEME_YX,       COLOR_YELLOW,   COLOR_BLACK);

--- a/src/colors.c
+++ b/src/colors.c
@@ -9,7 +9,8 @@ void colors_initialize() {
     init_color(COLOR_WHITE, 1000, 1000, 1000);
     init_pair(COLORSCHEME_DEFAULT,  COLOR_WHITE,    COLOR_BLACK);
     init_pair(COLORSCHEME_BW,       COLOR_BLACK,    COLOR_WHITE);
-    init_pair(COLORSCHEME_YB,       COLOR_YELLOW,   COLOR_BLUE);
-    init_pair(COLORSCHEME_BY,       COLOR_BLUE,     COLOR_YELLOW);
+    init_pair(COLORSCHEME_WBL,      COLOR_WHITE,    COLOR_BLUE);
+    init_pair(COLORSCHEME_YBL,      COLOR_YELLOW,   COLOR_BLUE);
+    init_pair(COLORSCHEME_BLY,      COLOR_BLUE,     COLOR_YELLOW);
     init_pair(COLORSCHEME_YX,       COLOR_YELLOW,   COLOR_BLACK);
 }

--- a/src/colors.h
+++ b/src/colors.h
@@ -7,8 +7,9 @@ typedef enum colorschemes {
     COLORSCHEME_SYSTEM,
     COLORSCHEME_DEFAULT,    // WHITE-BLACK
     COLORSCHEME_BW,         // BLACK-WHITE
-    COLORSCHEME_BY,         // BLUE-YELLOW
-    COLORSCHEME_YB,         // YELLOW-BLUE
+    COLORSCHEME_WBL,        // WHITE-BLUE
+    COLORSCHEME_BLY,        // BLUE-YELLOW
+    COLORSCHEME_YBL,        // YELLOW-BLUE
     COLORSCHEME_YX,         // YELLOW-DEFAULT
     // TODO: Add colorscheme for each colorscheme in response (docs/parser/html.md)
 } colorschemes_t;

--- a/src/colors.h
+++ b/src/colors.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <curses.h>
+
+// Color pair 0 is reserved for the system:
+// https://linux.die.net/man/3/color_pair
+typedef enum colorschemes {
+    COLORSCHEME_SYSTEM,
+    COLORSCHEME_DEFAULT,
+    COLORSCHEME_HEADER,
+    // TODO: Add colorscheme for each colorscheme in response (docs/parser/html.md)
+} colorschemes_t;
+
+void colors_initialize();

--- a/src/colors.h
+++ b/src/colors.h
@@ -5,8 +5,9 @@
 // https://linux.die.net/man/3/color_pair
 typedef enum colorschemes {
     COLORSCHEME_SYSTEM,
-    COLORSCHEME_DEFAULT,
-    COLORSCHEME_HEADER,
+    COLORSCHEME_DEFAULT,    // WHITE-BLACK
+    COLORSCHEME_BY,         // BLUE-YELLOW
+    COLORSCHEME_YB,         // YELLOW-BLUE
     // TODO: Add colorscheme for each colorscheme in response (docs/parser/html.md)
 } colorschemes_t;
 

--- a/src/colors.h
+++ b/src/colors.h
@@ -6,6 +6,7 @@
 typedef enum colorschemes {
     COLORSCHEME_SYSTEM,
     COLORSCHEME_DEFAULT,    // WHITE-BLACK
+    COLORSCHEME_BW,         // BLACK-WHITE
     COLORSCHEME_BY,         // BLUE-YELLOW
     COLORSCHEME_YB,         // YELLOW-BLUE
     COLORSCHEME_YX,         // YELLOW-DEFAULT

--- a/src/colors.h
+++ b/src/colors.h
@@ -8,6 +8,7 @@ typedef enum colorschemes {
     COLORSCHEME_DEFAULT,    // WHITE-BLACK
     COLORSCHEME_BY,         // BLUE-YELLOW
     COLORSCHEME_YB,         // YELLOW-BLUE
+    COLORSCHEME_YX,         // YELLOW-DEFAULT
     // TODO: Add colorscheme for each colorscheme in response (docs/parser/html.md)
 } colorschemes_t;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,0 +1,81 @@
+#include "draw.h"
+#include "pages.h"
+
+static view_t current_view;
+
+void draw_error(WINDOW *win) {
+    const char *error_str = error_get_string();
+
+    if (!error_str) {
+        return;
+    }
+
+    mvwprintw(win, PAGE_LINES - 1, 0, error_str);
+}
+
+static void draw_help(WINDOW *win) {
+    wattron(win, A_STANDOUT);
+    mvwprintw(win, 0, 0, " HELP WINDOW ");
+    wattroff(win, A_STANDOUT);
+    mvwprintw(win, 2, 0, "q - Quit the program");
+}
+
+static void draw_empty_page(WINDOW *win) {
+    mvwprintw(win, 0, 0, "Empty page!");
+}
+
+void draw_main(WINDOW *win, page_t *page) {
+    if (error_is_set()) {
+        draw_error(win);
+    }
+
+    if (!page) {
+        draw_empty_page(win);
+        return;
+    }
+
+    wattron(win, A_STANDOUT);
+    mvwprintw(win, 0, 0, " MAIN WINDOW ");
+    wattroff(win, A_STANDOUT);
+    mvwprintw(win, 0, PAGE_COLS - 3, "%d", page->id);
+    wattron(win, COLOR_PAIR(COLORSCHEME_HEADER));
+    mvwprintw(win, 1, 0, "%s", page->title);
+    wattroff(win, COLOR_PAIR(COLORSCHEME_HEADER));
+}
+
+void draw(WINDOW *win, view_t view, page_t *page) {
+    wclear(win);
+    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+
+    // Fill with empty characters to show the background color
+    for (int i = 0; i < PAGE_LINES * PAGE_COLS; i++) {
+        waddch(win, ' ');
+    }
+
+    switch (view) {
+        case VIEW_MAIN:
+            draw_main(win, page);
+            break;
+        case VIEW_HELP:
+            draw_help(win);
+            break;
+        default:
+            break;
+    }
+
+    current_view = view;
+    wattroff(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+    wrefresh(win);
+}
+
+void draw_toggle_help(WINDOW *win, page_t *page) {
+    if (current_view == VIEW_HELP) {
+        draw(win, VIEW_MAIN, page);
+    } else {
+        draw(win, VIEW_HELP, page);
+    }
+}
+
+void draw_refresh_current(WINDOW *win, page_t *page) {
+    draw(win, current_view, page);
+}

--- a/src/draw.c
+++ b/src/draw.c
@@ -2,18 +2,20 @@
 
 static view_t current_view;
 
-/// @brief Prints a T in a 3x3 box 
+/// @brief Prints a T in a 3x3 box
 void print_logo_letter(WINDOW *win, int line, int *col) {
-    wattron(win, COLOR_PAIR(COLORSCHEME_BW));
+    wattron(win, COLOR_PAIR(COLORSCHEME_BW) | A_UNDERLINE);
     wmove(win, line, *col);
-    for (int i = 0; i < 3; i++) {
+    for (int i = 0; i < 6; i++) {
         waddch(win, ' ');
     }
-    wmove(win, line + 1, (*col) + 1);
+    wmove(win, line + 1, (*col) + 2);
+    for (int i = 0; i < 2; i++) {
+        waddch(win, ' ');
+    }
+    wmove(win, line + 2, (*col) + 2);
     waddch(win, ' ');
-    wmove(win, line + 2, (*col) + 1);
-    waddch(win, ' ');
-    wattroff(win, COLOR_PAIR(COLORSCHEME_BW));
+    wattroff(win, COLOR_PAIR(COLORSCHEME_BW) | A_UNDERLINE);
     *col += 3 + PAGE_SIDE_PADDING;
 }
 
@@ -29,13 +31,15 @@ void fill_rows(WINDOW *win, int *line, int rows, attr_t attr) {
 
 void print_logo(WINDOW *win, int *line) {
     int col = PAGE_SIDE_PADDING;
-    fill_rows(win, line, 4, COLOR_PAIR(COLORSCHEME_YB));
+    fill_rows(win, line, 4, COLOR_PAIR(COLORSCHEME_YBL));
     *line -= 3;
     print_logo_letter(win, *line, &col);
     print_logo_letter(win, *line, &col);
     print_logo_letter(win, *line, &col);
-    
-    mvwprintw(win, (*line) + 2, col + 7, "version: %s", VERSION);
+
+    wattron(win, COLOR_PAIR(COLORSCHEME_WBL));
+    mvwprintw(win, (*line) + 2, col + 2, "version: %s", VERSION);
+    wattroff(win, COLOR_PAIR(COLORSCHEME_WBL));
     *line += 3;
 }
 
@@ -123,8 +127,8 @@ static void draw_help(WINDOW *win) {
     print_keybinding(win, &line, "display (this) help page", "?");
     print_keybinding(win, &line, "quit", "q");
     line = PAGE_LINES - 2;
-    print_center(win, &line, "Page 1/1", PAGE_SIDE_PADDING_LG, COLOR_PAIR(COLORSCHEME_BY));
-    print_center_fill(win, &line, "? to close", COLOR_PAIR(COLORSCHEME_YB));
+    print_center(win, &line, "Page 1/1", PAGE_SIDE_PADDING_LG, COLOR_PAIR(COLORSCHEME_BLY));
+    print_center_fill(win, &line, "? to close", COLOR_PAIR(COLORSCHEME_YBL));
 }
 
 static void draw_empty_page(WINDOW *win) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -6,13 +6,17 @@ static view_t current_view;
 void print_logo_letter(WINDOW *win, int line, int *col) {
     wattron(win, COLOR_PAIR(COLORSCHEME_BW) | A_UNDERLINE);
     wmove(win, line, *col);
+
     for (int i = 0; i < 6; i++) {
         waddch(win, ' ');
     }
+
     wmove(win, line + 1, (*col) + 2);
+
     for (int i = 0; i < 2; i++) {
         waddch(win, ' ');
     }
+
     wmove(win, line + 2, (*col) + 2);
     waddch(win, ' ');
     wattroff(win, COLOR_PAIR(COLORSCHEME_BW) | A_UNDERLINE);
@@ -22,9 +26,11 @@ void print_logo_letter(WINDOW *win, int line, int *col) {
 void fill_rows(WINDOW *win, int *line, int rows, attr_t attr) {
     wattron(win, attr);
     wmove(win, *line, 0);
+
     for (int i = 0; i < rows * PAGE_COLS; i++) {
         waddch(win, ' ');
     }
+
     wattroff(win, attr);
     *line += rows;
 }
@@ -36,7 +42,6 @@ void print_logo(WINDOW *win, int *line) {
     print_logo_letter(win, *line, &col);
     print_logo_letter(win, *line, &col);
     print_logo_letter(win, *line, &col);
-
     wattron(win, COLOR_PAIR(COLORSCHEME_WBL));
     mvwprintw(win, (*line) + 2, col + 2, "version: %s", VERSION);
     wattroff(win, COLOR_PAIR(COLORSCHEME_WBL));
@@ -47,11 +52,10 @@ void print_keybinding(WINDOW *win, int *line, const char *desc, const char *key)
     int desc_length = strlen(desc);
     int key_length = strlen(key);
     int dots = PAGE_COLS - desc_length - key_length - 2 * (PAGE_SIDE_PADDING);
-
     wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
     mvwprintw(win, *line, PAGE_SIDE_PADDING, desc);
 
-    for (int i = 0; i < dots;i++) {
+    for (int i = 0; i < dots; i++) {
         waddch(win, '.');
     }
 
@@ -80,7 +84,6 @@ void print_toprow(WINDOW *win, int *line, const char *id, const char *title) {
 void print_center(WINDOW *win, int *line, const char *str, int side_padding, attr_t attrs) {
     int str_length = strlen(str);
     int center_start = (PAGE_COLS - str_length) / 2;
-
     wattron(win, attrs);
     wmove(win, *line, center_start - side_padding);
 
@@ -158,14 +161,16 @@ void draw(WINDOW *win, view_t view, page_t *page) {
     }
 
     switch (view) {
-        case VIEW_MAIN:
-            draw_main(win, page);
-            break;
-        case VIEW_HELP:
-            draw_help(win);
-            break;
-        default:
-            break;
+    case VIEW_MAIN:
+        draw_main(win, page);
+        break;
+
+    case VIEW_HELP:
+        draw_help(win);
+        break;
+
+    default:
+        break;
     }
 
     current_view = view;

--- a/src/draw.c
+++ b/src/draw.c
@@ -41,6 +41,9 @@ void draw_main(WINDOW *win, page_t *page) {
     wattron(win, COLOR_PAIR(COLORSCHEME_HEADER));
     mvwprintw(win, 1, 0, "%s", page->title);
     wattroff(win, COLOR_PAIR(COLORSCHEME_HEADER));
+    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+    mvwprintw(win, 2, 0, "\u00e5\u00e4\u00f6");
+    wattroff(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
 }
 
 void draw(WINDOW *win, view_t view, page_t *page) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -19,22 +19,25 @@ void print_keybinding(WINDOW *win, int *line, const char *desc, const char *key)
     int key_length = strlen(key);
     int dots = PAGE_COLS - desc_length - key_length - 2 * (PAGE_SIDE_PADDING);
 
+    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
     mvwprintw(win, *line, PAGE_SIDE_PADDING, desc);
 
     for (int i = 0; i < dots;i++) {
         waddch(win, '.');
     }
 
+    wattron(win, COLOR_PAIR(COLORSCHEME_YX));
     wprintw(win, key);
+    wattroff(win, COLOR_PAIR(COLORSCHEME_YX));
     *line += 1;
 }
 
-void print_bold_title(WINDOW *win, int *line, const char *title, attr_t attrs) {
+void print_bold_title(WINDOW *win, int *line, const char *title) {
     // Add empty line above
     *line += 1;
-    wattron(win, A_BOLD | attrs);
+    wattron(win, A_BOLD | COLOR_PAIR(COLORSCHEME_YX));
     mvwprintw(win, *line, PAGE_SIDE_PADDING, title);
-    wattroff(win, A_BOLD | attrs);
+    wattroff(win, A_BOLD | COLOR_PAIR(COLORSCHEME_YX));
     *line += 1;
 }
 
@@ -57,7 +60,14 @@ void print_center(WINDOW *win, int *line, const char *str, int side_padding, att
     }
 
     mvwprintw(win, *line, center_start, str);
+    wattroff(win, attrs);
     *line += 1;
+}
+
+void print_center_fill(WINDOW *win, int *line, const char *str, attr_t attrs) {
+    fill_rows(win, line, 1, attrs);
+    *line -= 1;
+    print_center(win, line, str, 0, attrs);
 }
 
 void draw_error(WINDOW *win) {
@@ -74,18 +84,22 @@ static void draw_help(WINDOW *win) {
     int line = 0;
     print_toprow(win, &line, "0", "Keybindings");
     fill_rows(win, &line, 4, COLOR_PAIR(COLORSCHEME_YB));
-    print_bold_title(win, &line, "Navigation", 0);
+    print_bold_title(win, &line, "Navigation");
     print_keybinding(win, &line, "previous page", "h");
     print_keybinding(win, &line, "select next link on page", "j");
     print_keybinding(win, &line, "select previous link on page", "k");
     print_keybinding(win, &line, "next page", "l");
+    print_keybinding(win, &line, "show index page", "i");
     print_keybinding(win, &line, "go to selected link", "enter");
-    print_bold_title(win, &line, "General", 0);
+    print_bold_title(win, &line, "Command mode");
+    print_keybinding(win, &line, "enter command mode", ":");
+    print_keybinding(win, &line, "go to page", ":<page-number>");
+    print_bold_title(win, &line, "General");
     print_keybinding(win, &line, "display (this) help page", "?");
     print_keybinding(win, &line, "quit", "q");
     line = PAGE_LINES - 2;
     print_center(win, &line, "Page 1/1", PAGE_SIDE_PADDING_LG, COLOR_PAIR(COLORSCHEME_BY));
-    fill_rows(win, &line, 1, COLOR_PAIR(COLORSCHEME_YB));
+    print_center_fill(win, &line, "? to close", COLOR_PAIR(COLORSCHEME_YB));
 }
 
 static void draw_empty_page(WINDOW *win) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -3,6 +3,63 @@
 
 static view_t current_view;
 
+void fill_rows(WINDOW *win, int *line, int rows, attr_t attr) {
+    wattron(win, attr);
+    wmove(win, *line, 0);
+    for (int i = 0; i < rows * PAGE_COLS; i++) {
+        waddch(win, ' ');
+    }
+    wattroff(win, attr);
+    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+    *line += rows;
+}
+
+void print_keybinding(WINDOW *win, int *line, const char *desc, const char *key) {
+    int desc_length = strlen(desc);
+    int key_length = strlen(key);
+    int dots = PAGE_COLS - desc_length - key_length - 2 * (PAGE_SIDE_PADDING);
+
+    mvwprintw(win, *line, PAGE_SIDE_PADDING, desc);
+
+    for (int i = 0; i < dots;i++) {
+        waddch(win, '.');
+    }
+
+    wprintw(win, key);
+    *line += 1;
+}
+
+void print_bold_title(WINDOW *win, int *line, const char *title, attr_t attrs) {
+    // Add empty line above
+    *line += 1;
+    wattron(win, A_BOLD | attrs);
+    mvwprintw(win, *line, PAGE_SIDE_PADDING, title);
+    wattroff(win, A_BOLD | attrs);
+    *line += 1;
+}
+
+void print_toprow(WINDOW *win, int *line, const char *id, const char *title) {
+    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+    mvwprintw(win, *line, 0, id);
+    mvwprintw(win, *line, strlen(id) + 1, title);
+    *line += 1;
+}
+
+void print_center(WINDOW *win, int *line, const char *str, int side_padding, attr_t attrs) {
+    int str_length = strlen(str);
+    int center_start = (PAGE_COLS - str_length) / 2;
+
+    wattron(win, attrs);
+    wmove(win, *line, center_start - side_padding);
+
+    for (int i = 0; i < str_length + 2 * side_padding; i++) {
+        waddch(win, ' ');
+    }
+
+    mvwprintw(win, *line, center_start, str);
+    *line += 1;
+}
+
 void draw_error(WINDOW *win) {
     const char *error_str = error_get_string();
 
@@ -14,10 +71,21 @@ void draw_error(WINDOW *win) {
 }
 
 static void draw_help(WINDOW *win) {
-    wattron(win, A_STANDOUT);
-    mvwprintw(win, 0, 0, " HELP WINDOW ");
-    wattroff(win, A_STANDOUT);
-    mvwprintw(win, 2, 0, "q - Quit the program");
+    int line = 0;
+    print_toprow(win, &line, "0", "Keybindings");
+    fill_rows(win, &line, 4, COLOR_PAIR(COLORSCHEME_YB));
+    print_bold_title(win, &line, "Navigation", 0);
+    print_keybinding(win, &line, "previous page", "h");
+    print_keybinding(win, &line, "select next link on page", "j");
+    print_keybinding(win, &line, "select previous link on page", "k");
+    print_keybinding(win, &line, "next page", "l");
+    print_keybinding(win, &line, "go to selected link", "enter");
+    print_bold_title(win, &line, "General", 0);
+    print_keybinding(win, &line, "display (this) help page", "?");
+    print_keybinding(win, &line, "quit", "q");
+    line = PAGE_LINES - 2;
+    print_center(win, &line, "Page 1/1", PAGE_SIDE_PADDING_LG, COLOR_PAIR(COLORSCHEME_BY));
+    fill_rows(win, &line, 1, COLOR_PAIR(COLORSCHEME_YB));
 }
 
 static void draw_empty_page(WINDOW *win) {
@@ -34,16 +102,7 @@ void draw_main(WINDOW *win, page_t *page) {
         return;
     }
 
-    wattron(win, A_STANDOUT);
-    mvwprintw(win, 0, 0, " MAIN WINDOW ");
-    wattroff(win, A_STANDOUT);
-    mvwprintw(win, 0, PAGE_COLS - 3, "%d", page->id);
-    wattron(win, COLOR_PAIR(COLORSCHEME_HEADER));
-    mvwprintw(win, 1, 0, "%s", page->title);
-    wattroff(win, COLOR_PAIR(COLORSCHEME_HEADER));
-    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
-    mvwprintw(win, 2, 0, "\u00e5\u00e4\u00f6");
-    wattroff(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
+    // TODO: Render page
 }
 
 void draw(WINDOW *win, view_t view, page_t *page) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,7 +1,21 @@
 #include "draw.h"
-#include "pages.h"
 
 static view_t current_view;
+
+/// @brief Prints a T in a 3x3 box 
+void print_logo_letter(WINDOW *win, int line, int *col) {
+    wattron(win, COLOR_PAIR(COLORSCHEME_BW));
+    wmove(win, line, *col);
+    for (int i = 0; i < 3; i++) {
+        waddch(win, ' ');
+    }
+    wmove(win, line + 1, (*col) + 1);
+    waddch(win, ' ');
+    wmove(win, line + 2, (*col) + 1);
+    waddch(win, ' ');
+    wattroff(win, COLOR_PAIR(COLORSCHEME_BW));
+    *col += 3 + PAGE_SIDE_PADDING;
+}
 
 void fill_rows(WINDOW *win, int *line, int rows, attr_t attr) {
     wattron(win, attr);
@@ -10,8 +24,19 @@ void fill_rows(WINDOW *win, int *line, int rows, attr_t attr) {
         waddch(win, ' ');
     }
     wattroff(win, attr);
-    wattron(win, COLOR_PAIR(COLORSCHEME_DEFAULT));
     *line += rows;
+}
+
+void print_logo(WINDOW *win, int *line) {
+    int col = PAGE_SIDE_PADDING;
+    fill_rows(win, line, 4, COLOR_PAIR(COLORSCHEME_YB));
+    *line -= 3;
+    print_logo_letter(win, *line, &col);
+    print_logo_letter(win, *line, &col);
+    print_logo_letter(win, *line, &col);
+    
+    mvwprintw(win, (*line) + 2, col + 7, "version: %s", VERSION);
+    *line += 3;
 }
 
 void print_keybinding(WINDOW *win, int *line, const char *desc, const char *key) {
@@ -83,7 +108,7 @@ void draw_error(WINDOW *win) {
 static void draw_help(WINDOW *win) {
     int line = 0;
     print_toprow(win, &line, "0", "Keybindings");
-    fill_rows(win, &line, 4, COLOR_PAIR(COLORSCHEME_YB));
+    print_logo(win, &line);
     print_bold_title(win, &line, "Navigation");
     print_keybinding(win, &line, "previous page", "h");
     print_keybinding(win, &line, "select next link on page", "j");

--- a/src/draw.h
+++ b/src/draw.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <curses.h>
+
+#include "pages.h"
+#include "colors.h"
+#include "errors.h"
+#include "shared.h"
+
+typedef enum view {
+    VIEW_MAIN,
+    VIEW_HELP
+} view_t;
+
+void draw(WINDOW *win, view_t current, page_t *page);
+void draw_toggle_help(WINDOW *win, page_t *page);
+void draw_refresh_current(WINDOW *win, page_t *page);

--- a/src/errors.c
+++ b/src/errors.c
@@ -29,16 +29,20 @@ const char *error_get_string() {
 
     // Default error code messages
     switch (code) {
-        case TTT_ERROR_OUT_OF_MEMORY:
-            return "ERROR: Out of memory";
-        case TTT_ERROR_REQUEST_FAILED:
-            return "ERROR: HTTP request failed";
-        case TTT_ERROR_PAGE_PARSER_FAILED:
-            return "ERROR: Could not parse response";
-        case TTT_ERROR_HTML_PARSER_FAILED:
-            return "ERROR: Could not parse HTML page content";
-        default:
-            return "ERROR: Unknown";
+    case TTT_ERROR_OUT_OF_MEMORY:
+        return "ERROR: Out of memory";
+
+    case TTT_ERROR_REQUEST_FAILED:
+        return "ERROR: HTTP request failed";
+
+    case TTT_ERROR_PAGE_PARSER_FAILED:
+        return "ERROR: Could not parse response";
+
+    case TTT_ERROR_HTML_PARSER_FAILED:
+        return "ERROR: Could not parse HTML page content";
+
+    default:
+        return "ERROR: Unknown";
     }
 }
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -1,0 +1,47 @@
+#include "errors.h"
+
+static const char *custom_error_string = NULL;
+
+void error_set(ttt_error_t code) {
+    errno = code;
+    custom_error_string = NULL;
+}
+
+void error_set_with_string(ttt_error_t code, const char *str) {
+    errno = code;
+    custom_error_string = str;
+}
+
+bool error_is_set() {
+    return errno != TTT_ERROR_NONE;
+}
+
+const char *error_get_string() {
+    if (!error_is_set()) {
+        return NULL;
+    }
+
+    if (custom_error_string) {
+        return custom_error_string;
+    }
+
+    ttt_error_t code = errno;
+
+    // Default error code messages
+    switch (code) {
+        case TTT_ERROR_OUT_OF_MEMORY:
+            return "ERROR: Out of memory";
+        case TTT_ERROR_REQUEST_FAILED:
+            return "ERROR: HTTP request failed";
+        case TTT_ERROR_PAGE_PARSER_FAILED:
+            return "ERROR: Could not parse response";
+        case TTT_ERROR_HTML_PARSER_FAILED:
+            return "ERROR: Could not parse HTML page content";
+        default:
+            return "ERROR: Unknown";
+    }
+}
+
+void error_reset() {
+    error_set(TTT_ERROR_NONE);
+}

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdlib.h>
+#include <stdbool.h>
+#include <errno.h>
+
+extern int errno;
+
+typedef enum ttt_error {
+    TTT_ERROR_NONE,
+    TTT_ERROR_OUT_OF_MEMORY,
+    TTT_ERROR_REQUEST_FAILED,
+    TTT_ERROR_PAGE_PARSER_FAILED,
+    TTT_ERROR_HTML_PARSER_FAILED,
+} ttt_error_t;
+
+bool error_is_set();
+void error_set(ttt_error_t code);
+void error_set_with_string(ttt_error_t code, const char *str);
+ttt_error_t error_get();
+const char *error_get_string();
+void error_reset();

--- a/src/main.c
+++ b/src/main.c
@@ -3,13 +3,16 @@
 #include "pages.h"
 #include "parser.h"
 
+
 int main(void) {
     ui_initialize();
     api_initialize();
     
-    page_collection_t *test = api_get_page_range(HOME, FOREIGN_NEWS);
-    page_collection_print(test, "TEST");
-    page_collection_destroy(test);
+    //page_collection_t *test = api_get_page_range(HOME, FOREIGN_NEWS);
+    //page_collection_print(test, "TEST");
+    //page_collection_destroy(test);
+    ui_event_loop();
+    
     api_destroy();
     ui_destroy();
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -1,12 +1,19 @@
 #include "ui.h"
 #include <unistd.h>
 
-// TODO: Add CLI-arguments
-int main(void) {
+int main(int argc, char *argv[]) {
     ui_initialize();
     ui_event_loop();
     ui_destroy();
 
-    execlp("reset", "reset", NULL);
+    if (argc > 1) {
+        // Resetting is really slow, so we hide it behind '-r'
+        if (strcmp(argv[1], "-r") == 0) {
+            // Seems like this is one of the only ways to actually restore the terminal colors
+            // https://stackoverflow.com/questions/8686368/how-can-the-original-terminal-palette-be-acquired-preferably-using-ncurses-rout
+            execlp("reset", "reset", NULL);
+        }
+    }
+
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,9 +1,12 @@
 #include "ui.h"
+#include <unistd.h>
 
 // TODO: Add CLI-arguments
 int main(void) {
     ui_initialize();
     ui_event_loop();
     ui_destroy();
+
+    execlp("reset", "reset", NULL);
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -4,10 +4,13 @@
 #include "parser.h"
 
 int main(void) {
+    ui_initialize();
     api_initialize();
+    
     page_collection_t *test = api_get_page_range(HOME, FOREIGN_NEWS);
     page_collection_print(test, "TEST");
     page_collection_destroy(test);
     api_destroy();
+    ui_destroy();
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,18 +1,36 @@
 #include "ui.h"
 #include <unistd.h>
 
+void print_help() {
+    printf("usage ./ttt [-h] [-r]\n\n");
+    printf("TTT - Terminal Text TV\n");
+    printf("An interface to Text TV written in C\n\n");
+    printf("optional arguments:\n");
+    printf("-h          show this help message\n");
+    printf("-r          restore terminal colors on quit\n");
+}
+
 int main(int argc, char *argv[]) {
-    ui_initialize();
-    ui_event_loop();
-    ui_destroy();
+    bool reset = false;
 
     if (argc > 1) {
         // Resetting is really slow, so we hide it behind '-r'
         if (strcmp(argv[1], "-r") == 0) {
-            // Seems like this is one of the only ways to actually restore the terminal colors
-            // https://stackoverflow.com/questions/8686368/how-can-the-original-terminal-palette-be-acquired-preferably-using-ncurses-rout
-            execlp("reset", "reset", NULL);
+            reset = true;
+        } else {
+            print_help();
+            return 1;
         }
+    }
+
+    ui_initialize();
+    ui_event_loop();
+    ui_destroy();
+
+    if (reset) {
+        // Seems like this is one of the only ways to actually restore the terminal colors
+        // https://stackoverflow.com/questions/8686368/how-can-the-original-terminal-palette-be-acquired-preferably-using-ncurses-rout
+        execlp("reset", "reset", NULL);
     }
 
     return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -1,19 +1,9 @@
 #include "ui.h"
-#include "api.h"
-#include "pages.h"
-#include "parser.h"
 
-
+// TODO: Add CLI-arguments
 int main(void) {
     ui_initialize();
-    api_initialize();
-    
-    //page_collection_t *test = api_get_page_range(HOME, FOREIGN_NEWS);
-    //page_collection_print(test, "TEST");
-    //page_collection_destroy(test);
     ui_event_loop();
-    
-    api_destroy();
     ui_destroy();
     return 0;
 }

--- a/src/pages.c
+++ b/src/pages.c
@@ -77,7 +77,7 @@ void page_rows_destroy(page_row_t **rows) {
         return;
     }
 
-    for (size_t i = 0; i < PAGE_ROWS; i++) {
+    for (size_t i = 0; i < PAGE_LINES; i++) {
         free(rows[i]);
     }
 

--- a/src/pages.c
+++ b/src/pages.c
@@ -6,7 +6,7 @@ static page_t empty_page = {
     .next_id = -1,
     .unix_date = -1,
     .title = NULL,
-    .rows = NULL
+    .tokens = NULL
 };
 
 page_t *page_create_empty() {
@@ -72,20 +72,20 @@ void page_collection_print(page_collection_t *collection, const char *name) {
     }
 }
 
-void page_rows_destroy(page_row_t **rows) {
-    if (!rows) {
+void page_tokens_destroy(page_token_t **tokens) {
+    if (!tokens) {
         return;
     }
 
     for (size_t i = 0; i < PAGE_LINES; i++) {
-        free(rows[i]);
+        free(tokens[i]);
     }
 
-    free(rows);
+    free(tokens);
 }
 
 void page_destroy(page_t *page) {
-    page_rows_destroy(page->rows);
+    page_tokens_destroy(page->tokens);
     free(page->title);
     free(page);
 }

--- a/src/pages.c
+++ b/src/pages.c
@@ -6,7 +6,7 @@ static page_t empty_page = {
     .next_id = -1,
     .unix_date = -1,
     .title = NULL,
-    .content = NULL
+    .rows = NULL
 };
 
 page_t *page_create_empty() {
@@ -72,18 +72,20 @@ void page_collection_print(page_collection_t *collection, const char *name) {
     }
 }
 
-void page_content_destroy(page_content_t *content) {
-    if (!content) {
+void page_rows_destroy(page_row_t **rows) {
+    if (!rows) {
         return;
     }
 
-    free(content->title);
-    free(content->text);
-    free(content);
+    for (size_t i = 0; i < PAGE_ROWS; i++) {
+        free(rows[i]);
+    }
+
+    free(rows);
 }
 
 void page_destroy(page_t *page) {
-    page_content_destroy(page->content);
+    page_rows_destroy(page->rows);
     free(page->title);
     free(page);
 }

--- a/src/pages.h
+++ b/src/pages.h
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+
 #include "shared.h"
 
 typedef struct page page_t;

--- a/src/pages.h
+++ b/src/pages.h
@@ -5,27 +5,61 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
+#include "shared.h"
 
 typedef struct page page_t;
+typedef struct page_row page_row_t;
+typedef struct page_token page_token_t;
+typedef struct page_token_style page_token_style_t;
 typedef struct page_collection page_collection_t;
-typedef struct page_content page_content_t;
-typedef enum page_content_type_t {
-    HEADLINE,
-    ARTICLE
-} page_content_type_t;
 
-struct page_content {
-    char *title;
+typedef enum page_token_attr {
+    PAGE_TOKEN_ATTR_BOLD,       // .DH
+    PAGE_TOKEN_ATTR_BLUE,       // .B
+    PAGE_TOKEN_ATTR_CYAN,       // .C
+    PAGE_TOKEN_ATTR_WHITE,      // .W
+    PAGE_TOKEN_ATTR_GREEN,      // .G
+    PAGE_TOKEN_ATTR_YELLOW,     // .Y
+    PAGE_TOKEN_ATTR_RED,        // .R
+    PAGE_TOKEN_ATTR_BG_BLUE,    // .bgB
+    PAGE_TOKEN_ATTR_BG_CYAN,    // .bgC
+    PAGE_TOKEN_ATTR_BG_WHITE,   // .bgW
+    PAGE_TOKEN_ATTR_BG_GREEN,   // .bgG
+    PAGE_TOKEN_ATTR_BG_YELLOW,  // .bgY
+    PAGE_TOKEN_ATTR_BG_RED,     // .bgR
+} page_token_attr_t;
+
+typedef enum page_token_type {
+    PAGE_TOKEN_HEADER,          // .toprow
+    PAGE_TOKEN_TEXT,            // -
+    PAGE_TOKEN_WHITESPACE,      // -
+    PAGE_TOKEN_LINK,            // <a>
+    PAGE_TOKEN_END,             // \n
+} page_token_type_t;
+
+struct page_token_style {
+    page_token_attr_t fg;
+    page_token_attr_t bg;
+    page_token_attr_t extra;
+};
+
+struct page_token {
     char *text;
-    uint16_t id;
-    page_content_type_t type;
+    uint8_t size;
+    page_token_type_t type;
+    page_token_style_t style;
+};
+
+struct page_row {
+    // An array of tokens terminated by a page_token_t with type 'PAGE_TOKEN_END'
+    page_token_t *tokens;
 };
 
 struct page {
+    char *title;
     uint16_t id, prev_id, next_id;
     uint64_t unix_date;
-    char *title;
-    page_content_t *content;
+    page_row_t **rows;
 };
 
 struct page_collection {
@@ -38,6 +72,6 @@ page_collection_t *page_collection_create(size_t size);
 bool page_is_empty(page_t *page);
 void page_collection_resize(page_collection_t *collection, size_t new_size);
 void page_destroy(page_t *page);
-void page_content_destroy(page_content_t *content);
+void page_rows_destroy(page_row_t **rows);
 void page_collection_destroy(page_collection_t *collection);
 void page_collection_print(page_collection_t *collection, const char *name);

--- a/src/pages.h
+++ b/src/pages.h
@@ -9,7 +9,6 @@
 #include "shared.h"
 
 typedef struct page page_t;
-typedef struct page_row page_row_t;
 typedef struct page_token page_token_t;
 typedef struct page_token_style page_token_style_t;
 typedef struct page_collection page_collection_t;
@@ -35,7 +34,8 @@ typedef enum page_token_type {
     PAGE_TOKEN_TEXT,            // -
     PAGE_TOKEN_WHITESPACE,      // -
     PAGE_TOKEN_LINK,            // <a>
-    PAGE_TOKEN_END,             // \n
+    PAGE_TOKEN_NEWLINE,         // \n
+    PAGE_TOKEN_END,             // EOF
 } page_token_type_t;
 
 struct page_token_style {
@@ -46,21 +46,17 @@ struct page_token_style {
 
 struct page_token {
     char *text;
+    // A single tokens text may never exceed PAGE_COLS characters
     uint8_t size;
     page_token_type_t type;
     page_token_style_t style;
-};
-
-struct page_row {
-    // An array of tokens terminated by a page_token_t with type 'PAGE_TOKEN_END'
-    page_token_t *tokens;
 };
 
 struct page {
     char *title;
     uint16_t id, prev_id, next_id;
     uint64_t unix_date;
-    page_row_t **rows;
+    page_token_t **tokens;
 };
 
 struct page_collection {
@@ -73,6 +69,6 @@ page_collection_t *page_collection_create(size_t size);
 bool page_is_empty(page_t *page);
 void page_collection_resize(page_collection_t *collection, size_t new_size);
 void page_destroy(page_t *page);
-void page_rows_destroy(page_row_t **rows);
+void page_tokens_destroy(page_token_t **tokens);
 void page_collection_destroy(page_collection_t *collection);
 void page_collection_print(page_collection_t *collection, const char *name);

--- a/src/parser.c
+++ b/src/parser.c
@@ -138,15 +138,15 @@ static size_t get_unsigned_numeric(const char *data, jsmntok_t *cursor, size_t m
     return numeric;
 }
 
-page_content_t *parser_get_page_content(const char *content, size_t size) {
-    if (!content || size == 0) {
+page_row_t **parser_get_page_rows(const char *html, size_t size) {
+    if (!html || size == 0) {
         return NULL;
     }
 
     return NULL;
 }
 
-static page_content_t *parse_page_content(const char *data, jsmntok_t **cursor) {
+static page_row_t **get_rows(const char *data, jsmntok_t **cursor) {
     if ((*cursor)->type != JSMN_ARRAY) {
         return NULL;
     }
@@ -157,16 +157,15 @@ static page_content_t *parse_page_content(const char *data, jsmntok_t **cursor) 
         return NULL;
     }
 
+    // TODO: Add support for more than one element?
+    //       For certain pages, there are a "sub" page with other data, e.g. the stock market page
     // Go to the first array element
     next_token(cursor);
-    char *content_string = get_string(data, *cursor);
-    page_content_t *content = parser_get_page_content(
-                                  content_string,
-                                  token_length(*cursor)
-                              );
+    char *html = get_string(data, *cursor);
+    page_row_t **rows = parser_get_page_rows(html, token_length(*cursor));
     next_n_token(cursor, array_size - 1);
-    free(content_string);
-    return content;
+    free(html);
+    return rows;
 }
 
 static page_t *get_page(const char *data, jsmntok_t **cursor) {
@@ -190,7 +189,7 @@ static page_t *get_page(const char *data, jsmntok_t **cursor) {
         } else if (strcmp(key, "title") == 0) {
             page->title = get_unicode_string(data, *cursor);
         } else if (strcmp(key, "content") == 0) {
-            page->content = parse_page_content(data, cursor);
+            page->rows = get_rows(data, cursor);
         }
 
         free(key);

--- a/src/parser.c
+++ b/src/parser.c
@@ -75,7 +75,7 @@ static size_t get_unsigned_numeric(const char *data, jsmntok_t *cursor, size_t m
     return numeric;
 }
 
-page_row_t **parser_get_page_rows(const char *html, size_t size) {
+page_token_t **parser_get_page_tokens(const char *html, size_t size) {
     if (!html || size == 0) {
         error_set_with_string(
             TTT_ERROR_HTML_PARSER_FAILED,
@@ -87,7 +87,7 @@ page_row_t **parser_get_page_rows(const char *html, size_t size) {
     return NULL;
 }
 
-static page_row_t **get_rows(const char *data, jsmntok_t **cursor) {
+static page_token_t **get_tokens(const char *data, jsmntok_t **cursor) {
     if ((*cursor)->type != JSMN_ARRAY) {
         error_set_with_string(
             TTT_ERROR_HTML_PARSER_FAILED,
@@ -111,10 +111,10 @@ static page_row_t **get_rows(const char *data, jsmntok_t **cursor) {
     // Go to the first array element
     next_token(cursor);
     char *html = get_string(data, *cursor);
-    page_row_t **rows = parser_get_page_rows(html, token_length(*cursor));
+    page_token_t **tokens = parser_get_page_tokens(html, token_length(*cursor));
     next_n_token(cursor, array_size - 1);
     free(html);
-    return rows;
+    return tokens;
 }
 
 static page_t *get_page(const char *data, jsmntok_t **cursor) {
@@ -142,7 +142,7 @@ static page_t *get_page(const char *data, jsmntok_t **cursor) {
         } else if (strcmp(key, "title") == 0) {
             page->title = get_string(data, *cursor);
         } else if (strcmp(key, "content") == 0) {
-            page->rows = get_rows(data, cursor);
+            page->tokens = get_tokens(data, cursor);
         }
 
         free(key);

--- a/src/parser.h
+++ b/src/parser.h
@@ -9,5 +9,5 @@
 
 #include "pages.h"
 
-page_content_t *parser_get_page_content(const char *content, size_t size);
+page_t *parser_get_page_content(const char *content, size_t size);
 page_collection_t *parser_get_page_collection(const char *data, size_t size);

--- a/src/parser.h
+++ b/src/parser.h
@@ -8,6 +8,8 @@
 #include <limits.h>
 
 #include "pages.h"
+#include "shared.h"
+#include "errors.h"
 
 page_t *parser_get_page_content(const char *content, size_t size);
 page_collection_t *parser_get_page_collection(const char *data, size_t size);

--- a/src/shared.h
+++ b/src/shared.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define VERSION 0.1
+#define VERSION "0.1"
 #define PAGE_COLS 42
 #define PAGE_LINES 24
 #define PAGE_SIDE_PADDING 1

--- a/src/shared.h
+++ b/src/shared.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#define VERSION 0.1
 #define PAGE_COLS 42
 #define PAGE_LINES 24
+#define PAGE_SIDE_PADDING 1
+#define PAGE_SIDE_PADDING_LG 2
 #define MAX_PAGE_COLLECTION_SIZE 10

--- a/src/shared.h
+++ b/src/shared.h
@@ -1,2 +1,5 @@
+#pragma once
+
 #define PAGE_COLS 42
 #define PAGE_LINES 24
+#define MAX_PAGE_COLLECTION_SIZE 10

--- a/src/shared.h
+++ b/src/shared.h
@@ -1,0 +1,2 @@
+#define PAGE_COLS 42
+#define PAGE_LINES 24

--- a/src/ui.c
+++ b/src/ui.c
@@ -85,6 +85,8 @@ void ui_initialize() {
     initscr();
     noecho();
     nodelay(stdscr, TRUE);
+    // Hide cursor
+    curs_set(0);
     api_initialize();
     colors_initialize();
     create_win();

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,4 +1,5 @@
 #include "ui.h"
+#include <curses.h>
 #include <locale.h>
 
 enum views {
@@ -40,7 +41,9 @@ static void draw_main(page_t *page) {
         return;
     }
 
-    mvwprintw(content_win, 0, 0, "MAIN WINDOW");
+    wattron(content_win, A_STANDOUT);
+    mvwprintw(content_win, 0, 0, " MAIN WINDOW ");
+    wattroff(content_win, A_STANDOUT);
     mvwprintw(content_win, 0, PAGE_COLS - 3, "%d", current_collection->pages[0]->id);
     wattron(content_win, COLOR_PAIR(COLORSCHEME_HEADER));
     mvwprintw(content_win, 1, 0, "%s", current_collection->pages[0]->title);
@@ -48,7 +51,11 @@ static void draw_main(page_t *page) {
 }
 
 static void draw_help() {
-    mvwprintw(content_win, 0, 0, "HELP WINDOW");
+    wattron(content_win, A_STANDOUT);
+    mvwprintw(content_win, 0, 0, " HELP WINDOW ");
+    wattroff(content_win, A_STANDOUT);
+    mvwprintw(content_win, 2, 0, "q - Quit the program");
+
 }
 
 static void draw(enum views view) {

--- a/src/ui.c
+++ b/src/ui.c
@@ -46,11 +46,11 @@ static void set_page(uint16_t page) {
 
 static void create_win() {
     content_win = newwin(
-        PAGE_LINES,
-        PAGE_COLS,
-        (LINES - PAGE_LINES) / 2,
-        (COLS - PAGE_COLS) / 2
-    );
+                      PAGE_LINES,
+                      PAGE_COLS,
+                      (LINES - PAGE_LINES) / 2,
+                      (COLS - PAGE_COLS) / 2
+                  );
 }
 
 static void resize_win() {
@@ -109,11 +109,12 @@ void ui_event_loop() {
         key = wgetch(content_win);
 
         switch (key) {
-            case '?':
-                draw_toggle_help(content_win, current_page);
-                break;
-            case 'q':
-                return;
+        case '?':
+            draw_toggle_help(content_win, current_page);
+            break;
+
+        case 'q':
+            return;
         }
     }
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -3,8 +3,28 @@
 // TODO: Add window buffer cache to prevent rerendering of pages when switching between VIEW_MAIN and VIEW_HELP
 // TODO: Add window where we will echo and take input
 static WINDOW *content_win;
+static int current_page_index = -1;
 static page_t *current_page = NULL;
 static page_collection_t *current_collection;
+static char page_cache[MAX_PAGE_COLLECTION_SIZE][PAGE_LINES * PAGE_COLS];
+
+static void save_view_buffer() {
+    assert(current_page_index >= 0);
+    assert(current_page_index < MAX_PAGE_COLLECTION_SIZE);
+    mvwinstr(content_win, PAGE_LINES, PAGE_COLS, page_cache[current_page_index]);
+}
+
+static void restore_page_buffer(int index) {
+    assert(index >= 0);
+    assert(index < MAX_PAGE_COLLECTION_SIZE);
+
+    if (page_cache[index][0] == '\0') {
+        return;
+    }
+
+    mvwaddstr(content_win, PAGE_LINES, PAGE_COLS, page_cache[index]);
+    page_cache[index][0] = '\0';
+}
 
 static void set_page(uint16_t page) {
     error_reset();
@@ -18,7 +38,8 @@ static void set_page(uint16_t page) {
     current_collection->pages[0] = page_create_empty();
     current_collection->pages[0]->id = 100;
     current_collection->pages[0]->title = strdup("Test page title");
-    // TODO: set the current page accordingly
+    // TODO: set the current page and current_page_index accordingly
+    current_page_index = 0;
     current_page = current_collection->pages[0];
     draw(content_win, VIEW_MAIN, current_page);
 }
@@ -40,6 +61,8 @@ static void resize_handler(int sig) {
 void ui_initialize() {
     setlocale(LC_ALL, "");
     initscr();
+    noecho();
+    nodelay(stdscr, TRUE);
     api_initialize();
     colors_initialize();
     content_win = newwin(
@@ -49,8 +72,12 @@ void ui_initialize() {
         (COLS / 2) - (PAGE_COLS / 2)
     );
     signal(SIGWINCH, resize_handler);
-    noecho();
-    nodelay(stdscr, TRUE);
+
+    // By checking the first char of each page buffer cache we can detect empty buffers
+    for (int i = 0; i < MAX_PAGE_COLLECTION_SIZE; i++) {
+        page_cache[i][0] = '\0';
+    }
+
     refresh();
     set_page(TTT_PAGE_HOME);
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,95 +1,10 @@
 #include "ui.h"
-#include <curses.h>
-#include <locale.h>
-
-enum views {
-    VIEW_MAIN,
-    VIEW_HELP
-};
-
-// Color pair 0 is reserved for the system:
-// https://linux.die.net/man/3/color_pair
-enum colorschemes {
-    COLORSCHEME_SYSTEM,
-    COLORSCHEME_DEFAULT,
-    COLORSCHEME_HEADER,
-    // TODO: Add colorscheme for each colorscheme in response (docs/parser/html.md)
-};
 
 // TODO: Add window buffer cache to prevent rerendering of pages when switching between VIEW_MAIN and VIEW_HELP
 // TODO: Add window where we will echo and take input
 static WINDOW *content_win;
-static enum views current_view = VIEW_MAIN;
+static page_t *current_page = NULL;
 static page_collection_t *current_collection;
-
-static void draw_error() {
-    const char *error_str = error_get_string();
-
-    if (!error_str) {
-        return;
-    }
-
-    mvwprintw(content_win, PAGE_LINES - 1, 0, error_str);
-}
-
-static void draw_main(page_t *page) {
-    if (error_is_set()) {
-        draw_error();
-    }
-
-    if (!current_collection) {
-        return;
-    }
-
-    wattron(content_win, A_STANDOUT);
-    mvwprintw(content_win, 0, 0, " MAIN WINDOW ");
-    wattroff(content_win, A_STANDOUT);
-    mvwprintw(content_win, 0, PAGE_COLS - 3, "%d", current_collection->pages[0]->id);
-    wattron(content_win, COLOR_PAIR(COLORSCHEME_HEADER));
-    mvwprintw(content_win, 1, 0, "%s", current_collection->pages[0]->title);
-    wattroff(content_win, COLOR_PAIR(COLORSCHEME_HEADER));
-}
-
-static void draw_help() {
-    wattron(content_win, A_STANDOUT);
-    mvwprintw(content_win, 0, 0, " HELP WINDOW ");
-    wattroff(content_win, A_STANDOUT);
-    mvwprintw(content_win, 2, 0, "q - Quit the program");
-
-}
-
-static void draw(enum views view) {
-    wclear(content_win);
-    wattron(content_win, COLOR_PAIR(COLORSCHEME_DEFAULT));
-
-    // Fill with empty characters to show the background color
-    for (int i = 0; i < PAGE_LINES * PAGE_COLS; i++) {
-        waddch(content_win, ' ');
-    }
-
-    switch (view) {
-        case VIEW_MAIN:
-            draw_main(NULL);
-            break;
-        case VIEW_HELP:
-            draw_help();
-            break;
-        default:
-            break;
-    }
-
-    current_view = view;
-    wattroff(content_win, COLOR_PAIR(COLORSCHEME_DEFAULT));
-    wrefresh(content_win);
-}
-
-static void toggle_view() {
-    if (current_view == VIEW_MAIN) {
-        draw(VIEW_HELP);
-    } else {
-        draw(VIEW_MAIN);
-    }
-}
 
 static void set_page(uint16_t page) {
     error_reset();
@@ -103,7 +18,9 @@ static void set_page(uint16_t page) {
     current_collection->pages[0] = page_create_empty();
     current_collection->pages[0]->id = 100;
     current_collection->pages[0]->title = strdup("Test page title");
-    draw(VIEW_MAIN);
+    // TODO: set the current page accordingly
+    current_page = current_collection->pages[0];
+    draw(content_win, VIEW_MAIN, current_page);
 }
 
 static void resize_win() {
@@ -113,32 +30,18 @@ static void resize_win() {
     getmaxyx(stdscr, LINES, COLS);
     mvwin(content_win, (LINES / 2) - (PAGE_LINES / 2), (COLS / 2) - (PAGE_COLS / 2));
     refresh();
-    draw(current_view);
+    draw_refresh_current(content_win, current_page);
 }
 
 static void resize_handler(int sig) {
     resize_win();
 }
 
-static void set_colorschemes() {
-    start_color();
-    use_default_colors();
-    // TODO: Save initial colors and restore on exit
-    //       E.g. if using pywal and st, updating these will
-    //       actually set the colors globally for the current instance
-    init_color(COLOR_BLACK, 0, 0, 0);
-    init_color(COLOR_BLUE, 0, 0, 500);
-    init_color(COLOR_YELLOW, 1000, 1000, 0);
-    init_color(COLOR_WHITE, 1000, 1000, 1000);
-    init_pair(COLORSCHEME_DEFAULT, COLOR_WHITE,   COLOR_BLACK);
-    init_pair(COLORSCHEME_HEADER,  COLOR_YELLOW,  COLOR_BLUE);
-}
-
 void ui_initialize() {
     setlocale(LC_ALL, "");
-    api_initialize();
     initscr();
-    set_colorschemes();
+    api_initialize();
+    colors_initialize();
     content_win = newwin(
         PAGE_LINES,
         PAGE_COLS,
@@ -161,7 +64,7 @@ void ui_event_loop() {
 
         switch (key) {
             case '?':
-                toggle_view();
+                draw_toggle_help(content_win, current_page);
                 break;
             case 'q':
                 return;
@@ -172,7 +75,6 @@ void ui_event_loop() {
 void ui_destroy() {
     LINES = 0;
     COLS = 0;
-    current_view = VIEW_MAIN;
     page_collection_destroy(current_collection);
     delwin(content_win);
     endwin();

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,9 +1,15 @@
 #include <curses.h>
 
-void initialize_ui() {
-    initscr();              //Start curses mode
+static WINDOW *mainwin;
+
+void ui_initialize() {
+    mainwin = initscr();              //Start curses mode
     printw("Hello World!"); // Print to screen hello world.
     refresh();              // Print it to the real screen on the terminal
-    getch();                // wait for user input
-    endwin();               // End curses mode
+    //getch();                // wait for user input
+}
+
+void ui_destroy() {
+    delwin(mainwin);
+    endwin();
 }

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,15 +1,91 @@
-#include <curses.h>
+#include "ui.h"
 
-static WINDOW *mainwin;
+#define WIN_COLS 42
+#define WIN_ROWS 24
+
+enum views {
+    MAIN,
+    HELP
+};
+
+// TODO: Add window where we will echo and take input
+static WINDOW *CONTENT_WIN;
+static int _ROWS, _COLS;
+static enum views CURRENT_VIEW = MAIN;
+
+static void draw_main_view(page_t *page) {
+    mvwprintw(CONTENT_WIN, WIN_ROWS / 2, WIN_COLS / 2, "MAIN WINDOW");
+}
+
+static void draw_help_view() {
+    mvwprintw(CONTENT_WIN, WIN_ROWS / 2, WIN_COLS / 2, "HELP WINDOW");
+}
+
+static void draw(enum views view) {
+    wclear(CONTENT_WIN);
+    
+    switch (view) {
+        case MAIN:
+            draw_main_view(NULL);
+            break;
+        case HELP:
+            draw_help_view();
+            break;
+        default:
+            break;
+    }
+    
+    CURRENT_VIEW = view;
+    move(0, 0);
+    wborder(CONTENT_WIN, 0, 0, 0, 0, 0, 0, 0, 0);
+    wrefresh(CONTENT_WIN);
+}
+
+static void resize_win() {
+    getmaxyx(stdscr, _ROWS, _COLS);
+    CONTENT_WIN = newwin(
+        WIN_ROWS,
+        WIN_COLS,
+        (_ROWS / 2) - (WIN_ROWS / 2),
+        (_COLS / 2) - (WIN_COLS / 2)
+    );
+    draw(CURRENT_VIEW);
+}
+
+static void resize_handler(int sig) {
+    resize_win();
+}
 
 void ui_initialize() {
-    mainwin = initscr();              //Start curses mode
-    printw("Hello World!"); // Print to screen hello world.
-    refresh();              // Print it to the real screen on the terminal
-    //getch();                // wait for user input
+    initscr();
+    signal(SIGWINCH, resize_handler);
+    noecho();
+    nodelay(stdscr, TRUE);
+    refresh();
+    resize_win();
+}
+
+void ui_event_loop() {
+    int key;
+    
+    while (true)  {
+        key = getch();
+        switch (key) {
+            case '?':
+                draw(HELP);
+                break;
+            case 'x':
+                draw(MAIN);
+                break;
+            case 'q':
+                return;
+        }
+    }
 }
 
 void ui_destroy() {
-    delwin(mainwin);
+    _ROWS = 0;
+    _COLS = 0;
+    CURRENT_VIEW = MAIN;
     endwin();
 }

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <curses.h>
 #include <signal.h>
+#include "shared.h"
 #include "pages.h"
 
 void ui_initialize();

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <curses.h>
+#include <signal.h>
+#include "pages.h"
 
 void ui_initialize();
+void ui_event_loop();
 void ui_destroy();

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,8 +1,11 @@
 #pragma once
 #include <curses.h>
 #include <signal.h>
-#include "shared.h"
+
+#include "api.h"
 #include "pages.h"
+#include "errors.h"
+#include "shared.h"
 
 void ui_initialize();
 void ui_event_loop();

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,10 +1,12 @@
 #pragma once
 #include <curses.h>
 #include <signal.h>
+#include <locale.h>
 
 #include "api.h"
+#include "draw.h"
 #include "pages.h"
-#include "errors.h"
+#include "colors.h"
 #include "shared.h"
 
 void ui_initialize();

--- a/src/ui.h
+++ b/src/ui.h
@@ -1,4 +1,5 @@
 #pragma once
 #include <curses.h>
 
-void initialize_ui();
+void ui_initialize();
+void ui_destroy();

--- a/static/valgrind.supp
+++ b/static/valgrind.supp
@@ -168,3 +168,468 @@
    obj:/usr/lib64/libcurl.so.4.5.0
    fun:api_initialize
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:strdup
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_tparm_analyze
+   fun:tparm
+   fun:_nc_mvcur_init
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+   obj:/usr/lib64/libcurl.so.4.5.0
+   fun:api_initialize
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:lh_insert
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+   obj:/usr/lib64/libcurl.so.4.5.0
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_home_terminfo
+   fun:_nc_next_db
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:sk_new
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+   obj:/usr/lib64/libcurl.so.4.5.0
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:sk_new
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+   obj:/usr/lib64/libcurl.so.4.5.0
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:tparm
+   fun:_nc_mvcur_init
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:lh_new
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:lh_new
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:BIO_set
+   fun:BIO_new
+   fun:BIO_new_file
+   obj:/usr/lib64/libcrypto.so.1.0.2k
+   fun:CONF_modules_load_file
+   obj:/usr/lib64/libcurl.so.4.5.0
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_scroll_optimize
+   fun:doupdate
+   fun:wrefresh
+   fun:_nc_synchook
+   fun:wechochar
+   fun:_nc_wgetch
+   fun:wgetch
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_hash_map
+   fun:_nc_scroll_optimize
+   fun:doupdate
+   fun:wrefresh
+   fun:_nc_synchook
+   fun:wechochar
+   fun:_nc_wgetch
+   fun:wgetch
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_hash_map
+   fun:_nc_scroll_optimize
+   fun:doupdate
+   fun:wrefresh
+   fun:_nc_synchook
+   fun:wechochar
+   fun:_nc_wgetch
+   fun:wgetch
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_hash_map
+   fun:_nc_scroll_optimize
+   fun:doupdate
+   fun:wrefresh
+   fun:_nc_synchook
+   fun:wechochar
+   fun:_nc_wgetch
+   fun:wgetch
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_set_buffer
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   fun:_nc_read_file_entry
+   fun:_nc_read_entry
+   obj:/lib64/libtinfo.so.5.7
+   fun:_nc_setupterm
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_printf_string
+   fun:vwprintw
+   fun:printw
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:newwin
+   fun:_nc_setupscreen
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}

--- a/static/valgrind.supp
+++ b/static/valgrind.supp
@@ -633,3 +633,484 @@
    fun:ui_initialize
    fun:main
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:strdup
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:strdup
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_first_db
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_first_db
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_home_terminfo
+   fun:_nc_first_db
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:tparm
+   fun:_nc_mvcur_init_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_first_db
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_tparm_analyze
+   fun:tparm
+   fun:vid_puts_sp
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:doupdate_sp
+   fun:wrefresh
+   fun:draw
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_makenew_sp
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:new_prescr
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:realloc
+   fun:_nc_doalloc
+   fun:_nc_read_termtype
+   obj:/usr/lib/libncursesw.so.6.2
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_read_entry2
+   fun:_nc_setup_tinfo
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:/usr/lib/libncursesw.so.6.2
+   fun:_nc_setupterm
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_nc_init_wacs
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_printf_string_sp
+   fun:vwprintw
+   fun:mvwprintw
+   fun:draw_main_view
+   fun:draw
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:newwin_sp
+   fun:_nc_setupscreen_sp
+   fun:newterm_sp
+   fun:newterm
+   fun:initscr
+   fun:ui_initialize
+   fun:main
+}

--- a/test/unittests.c
+++ b/test/unittests.c
@@ -157,25 +157,6 @@ void test_page_single_char_title() {
     page_collection_destroy(collection);
 }
 
-void test_page_title_unescaped() {
-    char *str = "[{\"title\": \"abc-\\u00e4\\u00e5\\u00c4\\u00c5\\u00f6\\u00d6-def\"}]";
-    page_collection_t *collection = parser_get_page_collection(str, strlen(str));
-
-    assert_page_collection(collection, 1);
-
-    assert_parsed_page(
-        collection->pages[0],
-        -1,
-        -1,
-        -1,
-        -1,
-        "abc-aaAAoO-def",
-        false
-    );
-
-    page_collection_destroy(collection);
-}
-
 void test_page_invalid_keys() {
     char *str = "[{\"invalid\": \"asd\", \"xxx\": 100, \"yyy\": [\"zzz\"]}]";
     page_collection_t *collection = parser_get_page_collection(str, strlen(str));
@@ -309,7 +290,7 @@ void test_page_range() {
         100,
         101,
         1612004855,
-        "USA infor munskyddskrav for resande | Svensk test av virusmutationer drojer | Inrikes",
+        "USA inf\\u00f6r munskyddskrav f\\u00f6r resande | Svensk test av virusmutationer dr\\u00f6jer | Inrikes",
         false
     );
 
@@ -390,7 +371,7 @@ void test_page_range_large() {
         201,
         203,
         1612028945,
-        "Kalla:",
+        "K\\u00e4lla:",
         false
     );
 
@@ -400,7 +381,7 @@ void test_page_range_large() {
         202,
         204,
         1612028945,
-        "Kalla:",
+        "K\\u00e4lla:",
         false
     );
 
@@ -410,7 +391,7 @@ void test_page_range_large() {
         203,
         205,
         1612028945,
-        "Kalla:",
+        "K\\u00e4lla:",
         false
     );
 
@@ -420,7 +401,7 @@ void test_page_range_large() {
         204,
         206,
         1612028945,
-        "Kalla:",
+        "K\\u00e4lla:",
         false
     );
 
@@ -446,7 +427,6 @@ int main() {
     CU_add_test(page_parser_suite, "test_page_single_char_title", test_page_single_char_title);
     CU_add_test(page_parser_suite, "test_page_invalid_keys", test_page_invalid_keys);
     CU_add_test(page_parser_suite, "test_page_object_without_array", test_page_object_without_array);
-    CU_add_test(page_parser_suite, "test_page_title_unescaped", test_page_title_unescaped);
     CU_add_test(page_parser_suite, "test_page_invalid", test_page_invalid);
     CU_add_test(page_parser_suite, "test_page_collection_resize", test_page_collection_resize);
     CU_add_test(page_parser_suite, "test_page_large_content_array", test_page_large_content_array);

--- a/test/unittests.c
+++ b/test/unittests.c
@@ -77,7 +77,7 @@ void assert_parsed_page(
     uint16_t next_id,
     uint64_t unix_date,
     const char *title,
-    bool has_rows
+    bool has_tokens
 ) {
     CU_ASSERT_PTR_NOT_NULL_FATAL(page);
 
@@ -96,10 +96,10 @@ void assert_parsed_page(
         assert_string_value(page->title, title);
     }
 
-    if (!has_rows) {
-        CU_ASSERT_PTR_NULL(page->rows);
+    if (!has_tokens) {
+        CU_ASSERT_PTR_NULL(page->tokens);
     } else {
-        CU_ASSERT_PTR_NOT_NULL(page->rows);
+        CU_ASSERT_PTR_NOT_NULL(page->tokens);
     }
 }
 

--- a/test/unittests.c
+++ b/test/unittests.c
@@ -77,7 +77,7 @@ void assert_parsed_page(
     uint16_t next_id,
     uint64_t unix_date,
     const char *title,
-    page_content_t *content
+    bool has_rows
 ) {
     CU_ASSERT_PTR_NOT_NULL_FATAL(page);
 
@@ -96,11 +96,10 @@ void assert_parsed_page(
         assert_string_value(page->title, title);
     }
 
-    if (!content) {
-        CU_ASSERT_PTR_NULL(page->content);
+    if (!has_rows) {
+        CU_ASSERT_PTR_NULL(page->rows);
     } else {
-        CU_ASSERT_PTR_NOT_NULL(page->content);
-        // TODO: Compare content
+        CU_ASSERT_PTR_NOT_NULL(page->rows);
     }
 }
 
@@ -133,7 +132,7 @@ void test_page_empty_title() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -152,7 +151,7 @@ void test_page_single_char_title() {
         -1,
         -1,
         "x",
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -171,7 +170,7 @@ void test_page_title_unescaped() {
         -1,
         -1,
         "abc-aaAAoO-def",
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -190,7 +189,7 @@ void test_page_invalid_keys() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -208,7 +207,7 @@ void test_page_large_content_array() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -229,7 +228,7 @@ void test_page_invalid() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -250,7 +249,7 @@ void test_page_collection_resize() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -260,7 +259,7 @@ void test_page_collection_resize() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -270,7 +269,7 @@ void test_page_collection_resize() {
         -1,
         -1,
         NULL,
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -290,7 +289,7 @@ void test_page_single() {
         201,
         1612004371,
         "Svt",
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -311,7 +310,7 @@ void test_page_range() {
         101,
         1612004855,
         "USA infor munskyddskrav for resande | Svensk test av virusmutationer drojer | Inrikes",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -321,7 +320,7 @@ void test_page_range() {
         102,
         1612004794,
         "SVT Text",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -331,7 +330,7 @@ void test_page_range() {
         103,
         1612007994,
         "SVT Text",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -341,7 +340,7 @@ void test_page_range() {
         104,
         1612007994,
         "SVT Text",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -351,7 +350,7 @@ void test_page_range() {
         105,
         1612004496,
         "SVT Text",
-        NULL
+        false
     );
 
     page_collection_destroy(collection);
@@ -372,7 +371,7 @@ void test_page_range_large() {
         201,
         1612004371,
         "Svt",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -382,7 +381,7 @@ void test_page_range_large() {
         202,
         1612028945,
         "Svt",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -392,7 +391,7 @@ void test_page_range_large() {
         203,
         1612028945,
         "Kalla:",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -402,7 +401,7 @@ void test_page_range_large() {
         204,
         1612028945,
         "Kalla:",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -412,7 +411,7 @@ void test_page_range_large() {
         205,
         1612028945,
         "Kalla:",
-        NULL
+        false
     );
 
     assert_parsed_page(
@@ -422,7 +421,7 @@ void test_page_range_large() {
         206,
         1612028945,
         "Kalla:",
-        NULL
+        false
     );
 
     page_collection_destroy(collection);


### PR DESCRIPTION
The current UI has a centered window that will stay centered while resizing (with a few quirks). 

There are two different views, main and help. Opening the help screen is done by pressing `?`.  No other commands are currently implemented.

This is the current layout of the help page:
![image](https://user-images.githubusercontent.com/7253137/106904474-850d5500-66fb-11eb-8dc5-1cb7fa1dfe65.png)

Closes #8
Closes #16 (using the wchar_t version of ncurses, this is now working as expected)