### PR TITLE
feat: add command mode for manually setting page id and command(s)

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -286,7 +286,7 @@ void draw_help(WINDOW *win) {
     print_keybinding(win, &line, "go to page", ":<page-number>");
     print_bold_title(win, &line, "General");
     print_keybinding(win, &line, "display (this) help page", "?");
-    print_keybinding(win, &line, "quit", "q");
+    print_keybinding(win, &line, "quit", "q, :q, :Q");
     line = PAGE_LINES - 2;
     print_center(win, &line, "Page 1/1", PAGE_SIDE_PADDING_LG, COLOR_PAIR(COLORSCHEME_BLY));
     print_center_fill(win, &line, "? to close", COLOR_PAIR(COLORSCHEME_YBL));

--- a/src/draw.c
+++ b/src/draw.c
@@ -296,6 +296,33 @@ void draw_empty_page(WINDOW *win) {
     mvwprintw(win, 0, 0, "Empty page!");
 }
 
+void draw_command_start(WINDOW *win) {
+    wclear(win);
+    mvwaddch(win, 0, 1, ':');
+    wrefresh(win);
+}
+
+void draw_command_key(WINDOW *win, char key, int index) {
+    // Add 2 to the index to account for the left side padding (space + :)
+    mvwaddch(win, 0, index + 2, key);
+    wrefresh(win);
+}
+
+void draw_command_key_remove(WINDOW *win, int index) {
+    mvwdelch(win, 0, index + 2);
+    wrefresh(win);
+}
+
+void draw_command_message(WINDOW *win, char *str) {
+    wclear(win);
+
+    if (str) {
+        mvwaddstr(win, 0, 1, str);
+    }
+
+    wrefresh(win);
+}
+
 void draw_main(WINDOW *win, page_t *page) {
     if (error_is_set()) {
         draw_error(error_get_string());

--- a/src/draw.h
+++ b/src/draw.h
@@ -28,3 +28,8 @@ uint16_t draw_get_highlighted_link_href();
 int draw_get_current_view();
 int draw_get_highlighted_link_index();
 void draw_set_highlighted_link_index(WINDOW *win, int new_index);
+
+void draw_command_start(WINDOW *win);
+void draw_command_key(WINDOW *win, char key, int index);
+void draw_command_key_remove(WINDOW *win, int index);
+void draw_command_message(WINDOW *win, char *str);

--- a/src/html_parser.c
+++ b/src/html_parser.c
@@ -106,7 +106,6 @@ static void replace_unicode_escape_sequence(const char *html_content, int *start
 
 static void replace_html_escape_sequence(const char *html_content, int *start_index, char **dest, int *dest_position) {
     const char *sequence_start = html_content + (*start_index);
-
     int i = 0;
     char buf[MAX_HTML_ESCAPE_SEQUENCE_LENGTH];
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -171,7 +171,6 @@ page_t *parser_get_page(const char *data, size_t size) {
     }
 
     jsmntok_t *cursor = tokens;
-
     next_token(&cursor);
 
     // We only parse single pages, even if there are more than

--- a/src/ui.c
+++ b/src/ui.c
@@ -81,7 +81,6 @@ static void undo_follow_highlighted_link() {
 
     // Save the previous link index so that we can set it after rendering the page
     int link_index = previous_page_link_index;
-
     set_page_index(previous_page_index);
 
     if (link_index != -1) {
@@ -107,7 +106,6 @@ static void reset_command_mode_input(char buf[256], int *buf_length, bool *comma
     buf[*buf_length] = '\0';
     *buf_length = 0;
     *command_mode = false;
-
     draw_command_message(command_win, NULL);
 }
 
@@ -246,6 +244,7 @@ void ui_event_loop() {
                 draw_command_start(command_win);
                 command_mode = true;
                 break;
+
             case 'h':
             case 'p':
                 previous_page();

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,5 +1,9 @@
 #include "ui.h"
+#include <stdlib.h>
+#include <string.h>
 
+#define LOWERCASE_QUIT      "q"
+#define QUIT                "Q"
 #define ESCAPE              27
 #define DELETE              127
 #define BACKSPACE           8
@@ -119,9 +123,14 @@ static void remove_command_mode_key(char buf[256], int *buf_length) {
     draw_command_key_remove(command_win, *buf_length);
 }
 
-static void execute_command_mode_input(char buf[256], int length) {
+static void execute_command_mode_input(char buf[256], int length, int *break_loop) {
     // Clear input window
     draw_command_message(command_win, NULL);
+
+    if (strncmp(buf, LOWERCASE_QUIT, length) == 0 || strncmp(buf, QUIT, length) == 0) {
+        *break_loop = 1;
+        return;
+    }
 
     if (length == 0 || length > PAGE_ID_MAX_LENGTH) {
         return;
@@ -205,6 +214,7 @@ void ui_initialize(bool overwrite_colors, bool transparent_background) {
 void ui_event_loop() {
     int key;
     int buf_length = 0;
+    int break_loop = 0;
     char buf[256];
     bool command_mode = false;
 
@@ -225,7 +235,8 @@ void ui_event_loop() {
 
             case '\n':
                 reset_command_mode_input(buf, &buf_length, &command_mode);
-                execute_command_mode_input(buf, buf_length - 1);
+                execute_command_mode_input(buf, buf_length - 1, &break_loop);
+                if (break_loop) return;
                 break;
 
             // Colon is not a valid command character

--- a/src/ui.c
+++ b/src/ui.c
@@ -236,7 +236,11 @@ void ui_event_loop() {
             case '\n':
                 reset_command_mode_input(buf, &buf_length, &command_mode);
                 execute_command_mode_input(buf, buf_length - 1, &break_loop);
-                if (break_loop) return;
+
+                if (break_loop) {
+                    return;
+                }
+
                 break;
 
             // Colon is not a valid command character

--- a/src/ui.c
+++ b/src/ui.c
@@ -1,8 +1,14 @@
 #include "ui.h"
 
+#define ESCAPE              27
+#define DELETE              127
+#define BACKSPACE           8
+#define PAGE_ID_MAX_LENGTH  3
+
 // TODO: Add window buffer cache to prevent rerendering of pages when switching between VIEW_MAIN and VIEW_HELP
 // TODO: Add window where we will echo and take input
 static WINDOW *content_win;
+static WINDOW *command_win;
 static int current_page_index = -1;
 static int previous_page_index = -1;
 static int previous_page_link_index = -1;
@@ -97,11 +103,57 @@ static void follow_highlighted_link() {
     }
 }
 
+static void reset_command_mode_input(char buf[256], int *buf_length, bool *command_mode) {
+    buf[*buf_length] = '\0';
+    *buf_length = 0;
+    *command_mode = false;
+
+    draw_command_message(command_win, NULL);
+}
+
+static void remove_command_mode_key(char buf[256], int *buf_length) {
+    if (*buf_length == 0) {
+        return;
+    }
+
+    *buf_length -= 1;
+    buf[*buf_length] = '\0';
+    draw_command_key_remove(command_win, *buf_length);
+}
+
+static void execute_command_mode_input(char buf[256], int length) {
+    // Clear input window
+    draw_command_message(command_win, NULL);
+
+    if (length == 0 || length > PAGE_ID_MAX_LENGTH) {
+        return;
+    }
+
+    int id = atoi(buf);
+
+    if (!id || id < TTT_PAGE_HOME) {
+        draw_command_message(command_win, "Invalid page id");
+        return;
+    }
+
+    set_page(id);
+}
+
 static void create_win() {
     content_win = newwin(
                       PAGE_LINES,
                       PAGE_COLS,
                       (LINES - PAGE_LINES) / 2,
+                      (COLS - PAGE_COLS) / 2
+                  );
+}
+
+static void create_command_win() {
+    // Create window below the page window with a height of 1
+    command_win = newwin(
+                      1,
+                      PAGE_COLS,
+                      (LINES - PAGE_LINES) / 2 + PAGE_LINES,
                       (COLS - PAGE_COLS) / 2
                   );
 }
@@ -118,14 +170,17 @@ static void resize_win() {
     // try to create it again.
     if (!content_win) {
         create_win();
+        create_command_win();
     } else {
         // This fixes a bug where the window "collapses" on resize
         // and flows out to the side.
         wresize(content_win, PAGE_LINES, PAGE_COLS);
+        wresize(command_win, 1, PAGE_COLS);
     }
 
     // TODO: Move window to edges if the screen does not fit the window
     mvwin(content_win, (LINES - PAGE_LINES) / 2, (COLS - PAGE_COLS) / 2);
+    mvwin(command_win, (LINES - PAGE_LINES) / 2 + PAGE_LINES, (COLS - PAGE_COLS) / 2);
     draw_refresh_current(content_win, current_page);
 }
 
@@ -143,6 +198,7 @@ void ui_initialize(bool overwrite_colors, bool transparent_background) {
     collection = page_collection_create(0);
     colors_initialize(overwrite_colors, transparent_background);
     create_win();
+    create_command_win();
     signal(SIGWINCH, resize_handler);
     refresh();
     set_page(current_page_id);
@@ -150,53 +206,88 @@ void ui_initialize(bool overwrite_colors, bool transparent_background) {
 
 void ui_event_loop() {
     int key;
+    int buf_length = 0;
+    char buf[256];
+    bool command_mode = false;
 
     while (true) {
         // https://stackoverflow.com/questions/3808626/ncurses-refresh/3808913#3808913
         key = wgetch(content_win);
 
-        switch (key) {
-        case 'h':
-        case 'p':
-            previous_page();
-            break;
+        if (command_mode) {
+            switch (key) {
+            case ESCAPE:
+                reset_command_mode_input(buf, &buf_length, &command_mode);
+                break;
 
-        case 'j':
-            draw_next_link(content_win);
-            break;
+            case DELETE:
+            case BACKSPACE:
+                remove_command_mode_key(buf, &buf_length);
+                break;
 
-        case 'k':
-            draw_previous_link(content_win);
-            break;
+            case '\n':
+                reset_command_mode_input(buf, &buf_length, &command_mode);
+                execute_command_mode_input(buf, buf_length - 1);
+                break;
 
-        case 'l':
-        case 'n':
-            next_page();
-            break;
+            // Colon is not a valid command character
+            case ':':
+                break;
 
-        case '?':
-            draw_toggle_help(content_win, current_page);
-            break;
+            default:
+                draw_command_key(command_win, key, buf_length);
+                buf[buf_length] = key;
+                buf_length++;
+                break;
+            }
+        } else {
+            switch (key) {
+            case ':':
+                draw_command_start(command_win);
+                command_mode = true;
+                break;
+            case 'h':
+            case 'p':
+                previous_page();
+                break;
 
-        case '\n':
-            follow_highlighted_link();
-            break;
+            case 'j':
+                draw_next_link(content_win);
+                break;
 
-        case 'u':
-        case 'b':
-            undo_follow_highlighted_link();
-            break;
+            case 'k':
+                draw_previous_link(content_win);
+                break;
 
-        case 'i':
-            set_page(TTT_PAGE_CONTENTS);
-            break;
+            case 'l':
+            case 'n':
+                next_page();
+                break;
 
-        case 's':
-            set_page(TTT_PAGE_HOME);
-            break;
+            case '?':
+                draw_toggle_help(content_win, current_page);
+                break;
 
-        case 'q':
-            return;
+            case '\n':
+                follow_highlighted_link();
+                break;
+
+            case 'u':
+            case 'b':
+                undo_follow_highlighted_link();
+                break;
+
+            case 'i':
+                set_page(TTT_PAGE_CONTENTS);
+                break;
+
+            case 's':
+                set_page(TTT_PAGE_HOME);
+                break;
+
+            case 'q':
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
Adds a vim inspired normal/"command" mode. Currently, the only command supported is setting the page id, i.e. `:100`.

Closes #20.